### PR TITLE
Dynamic Power Characteristic for Player Characters via Talent Bonuses

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -71,6 +71,7 @@
     "DL.TalentBonuses": "Bonuses",
     "DL.TalentBonusesDefense": "Defense bonus",
     "DL.TalentBonusesHealth": "Health bonus",
+    "DL.TalentBonusesPower": "Power bonus",
     "DL.TalentBonusesSpeed": "Speed bonus",
     "DL.TalentMultipleOptions": "Multiple Options",
     "DL.TalentHasMultipleOptions": "The Talent has multiple options",

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -109,6 +109,7 @@ export class DemonlordActor extends Actor {
             data.characteristics.defense = parseInt(data.characteristics.defense) + parseInt(defenseBonus) + parseInt(agilitypoint);
 
         data.characteristics.defense = parseInt(data.characteristics.defense) + parseInt(characterbuffs.defensebonus);
+        data.characteristics.power = parseInt(characterbuffs.powerbonus);
 
         characterbuffs.speedbonus += speedPenalty;
 
@@ -149,6 +150,7 @@ export class DemonlordActor extends Actor {
             await this.update({
                 "data.characteristics.defensebonus": parseInt(characterbuffs.defensebonus) - (parseInt(child.data.bonuses.defense) ? parseInt(child.data.bonuses.defense) : 0),
                 "data.characteristics.healthbonus": parseInt(characterbuffs.healthbonus) - (parseInt(child.data.bonuses.health) ? parseInt(child.data.bonuses.health) : 0),
+                "data.characteristics.powerbonus": parseInt(characterbuffs.powerbonus) - (parseInt(child.data.bonuses.power) ? parseInt(child.data.bonuses.power) : 0),
                 "data.characteristics.speedbonus": parseInt(characterbuffs.speedbonus) - (parseInt(child.data.bonuses.speed) ? parseInt(child.data.bonuses.speed) : 0),
                 "data.characteristics.defense": parseInt(this.data.data.characteristics.defense) - (parseInt(child.data.bonuses.defense) ? parseInt(child.data.bonuses.defense) : 0),
                 "data.characteristics.health.max": parseInt(this.data.data.characteristics.health.max) - (parseInt(child.data.bonuses.health) ? parseInt(child.data.bonuses.health) : 0),
@@ -1011,6 +1013,9 @@ export class DemonlordActor extends Actor {
                 if (talent.data.bonuses?.healthactive && talent.data.bonuses?.health != "") {
                     characterbuffs.healthbonus += parseInt(talent.data.bonuses.health);
                 }
+                if (talent.data.bonuses?.poweractive && talent.data.bonuses?.power != "") {
+                    characterbuffs.powerbonus += parseInt(talent.data.bonuses.power);
+                }
                 if (talent.data.bonuses?.speedactive && talent.data.bonuses?.speed != "") {
                     characterbuffs.speedbonus += parseInt(talent.data.bonuses.speed);
                 }
@@ -1148,6 +1153,9 @@ export class DemonlordActor extends Actor {
             if (talent.data?.bonuses?.healthactive && talent.data?.bonuses?.health)
                 effects += "&nbsp;&nbsp;&nbsp;• " + game.i18n.localize('DL.TalentBonusesHealth') + ": " + talent.data.bonuses?.health
                     + "<br>";
+            if (talent.data?.bonuses?.poweractive && talent.data?.bonuses?.power)
+                effects += "&nbsp;&nbsp;&nbsp;• " + game.i18n.localize('DL.TalentBonusesPower') + ": " + talent.data.bonuses?.power
+                    + "<br>";
             if (talent.data?.bonuses?.speedactive && talent.data?.bonuses?.speed)
                 effects += "&nbsp;&nbsp;&nbsp;• " + game.i18n.localize('DL.TalentBonusesSpeed') + ": " + talent.data.bonuses?.speed
                     + "<br>";
@@ -1196,6 +1204,7 @@ export class DemonlordActor extends Actor {
     async addCharacterBonuses(talent) {
         const healthbonus = talent.data.bonuses?.defenseactive && talent.data.bonuses?.health != "" ? parseInt(talent.data.bonuses?.health) : 0;
         const defensebonus = talent.data.bonuses?.healthactive && talent.data.bonuses?.defense != "" ? parseInt(talent.data.bonuses?.defense) : 0;
+        const powerbonus = talent.data.bonuses?.poweractive && talent.data.bonuses?.power != "" ? parseInt(talent.data.bonuses?.power) : 0;
         const speedbonus = talent.data.bonuses?.speedactive && talent.data.bonuses?.speed != "" ? parseInt(talent.data.bonuses?.speed) : 0;
         /*
                 await this.update({
@@ -1210,11 +1219,13 @@ export class DemonlordActor extends Actor {
     async removeCharacterBonuses(talent) {
         const healthbonus = talent.data.bonuses?.defenseactive && talent.data.bonuses?.health != "" ? parseInt(talent.data.bonuses?.health) : 0;
         const defensebonus = talent.data.bonuses?.healthactive && talent.data.bonuses?.defense != "" ? parseInt(talent.data.bonuses?.defense) : 0;
+        const powerbonus = talent.data.bonuses?.poweractive && talent.data.bonuses?.power != "" ? parseInt(talent.data.bonuses?.power) : 0;
         const speedbonus = talent.data.bonuses?.speedactive && talent.data.bonuses?.speed != "" ? parseInt(talent.data.bonuses?.speed) : 0;
 
         await this.update({
             "data.characteristics.health.max": parseInt(this.data.data.characteristics.health.max) - healthbonus,
             "data.characteristics.defense": parseInt(this.data.data.characteristics.defense) - defensebonus,
+            "data.characteristics.power": parseInt(this.data.data.characteristics.power) - powerbonus,
             "data.characteristics.speed.value": parseInt(this.data.data.characteristics.speed.value) - speedbonus,
             "data.activebonuses": false
         });

--- a/module/buff.js
+++ b/module/buff.js
@@ -14,6 +14,7 @@ export class CharacterBuff {
         this.challengeeffects = obj.challengeeffects || "";
         this.defensebonus = obj.defensebonus || 0;
         this.healthbonus = obj.healthbonus || 0;
+        this.powerbonus = obj.powerbonus || 0;
         this.speedbonus = obj.speedactive || 0;
         this.healing = obj.healing || 0;
         this.strength = obj.strength || 0;

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -82,6 +82,7 @@ export class DemonlordItemSheet extends ItemSheet {
                 await this.actor.update({
                     "data.characteristics.defensebonus": parseInt(characterbuffs.defensebonus),
                     "data.characteristics.healthbonus": parseInt(characterbuffs.healthbonus),
+                    "data.characteristics.powerbonus": parseInt(characterbuffs.powerbonus),
                     "data.characteristics.speedbonus": parseInt(characterbuffs.speedbonus)
                 });
             } else {
@@ -106,6 +107,9 @@ export class DemonlordItemSheet extends ItemSheet {
                     }
                     if (talent.data.bonuses.healthactive && talent.data.bonuses.health != "") {
                         characterbuffs.healthbonus += parseInt(talent.data.bonuses.health);
+                    }
+                    if (talent.data.bonuses.poweractive && talent.data.bonuses.power != "") {
+                        characterbuffs.powerbonus += parseInt(talent.data.bonuses.power);
                     }
                     if (talent.data.bonuses.speedactive && talent.data.bonuses.speed != "") {
                         characterbuffs.speedbonus += parseInt(talent.data.bonuses.speed);

--- a/module/item/item-sheet2.js
+++ b/module/item/item-sheet2.js
@@ -82,6 +82,7 @@ export class DemonlordItemSheet2 extends ItemSheet {
                 await this.actor?.update({
                     "data.characteristics.defensebonus": parseInt(characterbuffs.defensebonus),
                     "data.characteristics.healthbonus": parseInt(characterbuffs.healthbonus),
+                    "data.characteristics.powerbonus": parseInt(characterbuffs.powerbonus),
                     "data.characteristics.speedbonus": parseInt(characterbuffs.speedbonus)
                 });
             } else {
@@ -107,6 +108,9 @@ export class DemonlordItemSheet2 extends ItemSheet {
                         }
                         if (talent.data.bonuses.healthactive && talent.data.bonuses.health != "") {
                             characterbuffs.healthbonus += parseInt(talent.data.bonuses.health);
+                        }
+                        if (talent.data.bonuses.poweractive && talent.data.bonuses.power != "") {
+                            characterbuffs.powerbonus += parseInt(talent.data.bonuses.power);
                         }
                         if (talent.data.bonuses.speedactive && talent.data.bonuses.speed != "") {
                             characterbuffs.speedbonus += parseInt(talent.data.bonuses.speed);

--- a/system.json
+++ b/system.json
@@ -81,8 +81,8 @@
 			"path": "lang/es.json"
 		}
     ],
-    "gridDistance": 5,
-    "gridUnits": "ft",
+    "gridDistance": 1,
+    "gridUnits": "yd",
     "primaryTokenAttribute": "characteristics.health",
     "secondaryTokenAttribute": "",
     "socket": true,

--- a/template.json
+++ b/template.json
@@ -277,6 +277,8 @@
                 "defense": "",
                 "healthactive": true,
                 "health": "",
+                "poweractive": true,
+                "power": "",
                 "speedactive": true,
                 "speed": ""
             },

--- a/templates/actor/actor-sheet.html
+++ b/templates/actor/actor-sheet.html
@@ -113,9 +113,8 @@
                         </div>
                     </div>
                     <div class="charbox">
-                        <div class="char">
-                            <input name="data.characteristics.power" type="text" value="{{data.characteristics.power}}"
-                                data-dtype="{{attribute.dtype}}" placeholder="" />
+                        <div class="charlabel">
+                            <div>{{data.characteristics.power}}</div>
                         </div>
                         <div class="chartext">
                             <label for="data.characteristics.power">{{localize "DL.CharPower"}}</label>

--- a/templates/actor/sidemenu.html
+++ b/templates/actor/sidemenu.html
@@ -76,10 +76,7 @@
             </div>
             <div class="powerbox">
                 <div class="powertext">{{localize "DL.CharPower"}}</div>
-                <div class="power">
-                    <input name="data.characteristics.power" type="text" value="{{data.characteristics.power}}"
-                        data-dtype="{{attribute.dtype}}" placeholder="" />
-                </div>
+                <div class="power">{{data.characteristics.power}}</div>
             </div>
         </div>
         <div class="chars grid grid-2col">

--- a/templates/item/item-talent-sheet.html
+++ b/templates/item/item-talent-sheet.html
@@ -130,6 +130,8 @@
                             <input type="text" name="data.bonuses.defense" value="{{data.bonuses.defense}}" />
                             <label class="resource-label">{{localize "DL.TalentBonusesHealth"}}</label>
                             <input type="text" name="data.bonuses.health" value="{{data.bonuses.health}}" />
+                            <label class="resource-label">{{localize "DL.TalentBonusesPower"}}</label>
+                            <input type="text" name="data.bonuses.power" value="{{data.bonuses.power}}" />
                             <label class="resource-label">{{localize "DL.TalentBonusesSpeed"}}</label>
                             <input type="text" name="data.bonuses.speed" value="{{data.bonuses.speed}}" />
                         </div>

--- a/templates/tabs/talents.html
+++ b/templates/tabs/talents.html
@@ -128,6 +128,15 @@
                 <b>{{localize 'DL.TalentBonusesHealth'}}:</b> {{data.bonuses.health}}
             </div>
             {{/if}}
+            {{#if data.bonuses.power}}
+            <div class="option" data-item-id="{{talent._id}}">
+                {{#if data.multipleoptions}}
+                <input type="checkbox" name="data.bonuses.poweractive" id="optionpoweractive{{talent._id}}"
+                    {{checked data.bonuses.poweractive}} />
+                {{/if}}
+                <b>{{localize 'DL.TalentBonusesPower'}}:</b> {{data.bonuses.power}}
+            </div>
+            {{/if}}
             {{#if data.bonuses.speed}}
             <div class="option" data-item-id="{{talent._id}}">
                 {{#if data.multipleoptions}}


### PR DESCRIPTION
This fundamentally changes the player character's **Power** characteristic via the usage of a Power Bonus within Talents (and talents alone). This aims to be consistent with the way that D&D5e aggregates several values. 

A few things to note:
1. As of right now, only English localization is supported because I'm sadly not fluent enough in the other languages.
2. This removes a player's ability to directly edit their own power and thus may cause potential conflicts with existing characters. The player character's power is always set to the collective power bonus from talents. If approved, we should notify active users of this system of the change.
3. I opted to make this power bonus an integer value (instead of a boolean) in the case that there is a path that increases power by more than an increment. I don't know of such a case (I am still new to this system), but I believe the flexibility is fine.
4. This PR is in preparation for dynamic spell usages based on this calculated power characteristic, which I will hopefully get to in a week or so.
5. This also changes the default grid layout to "1 yd" vs "5 ft". This change can be removed if necessary.

In the screenshot below, I have created two Talents corresponding to the Priest Level 1 and Spellbinder Level 3 which each have a Power Bonus of 1. 
![image](https://user-images.githubusercontent.com/7025561/96002095-bd182180-0e06-11eb-821a-4b1fd973c3cc.png)