### PR TITLE
New hooks to automated animations

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -412,7 +412,9 @@ export class DemonlordActor extends Actor {
       const attackFormula = '1d20' + plusify(attackModifier) + (attackBoons ? plusify(attackBoons) + 'd6kh' : '')
       attackRoll = new Roll(attackFormula, {})
       attackRoll.evaluate()
-    } else if (spellData.action.damage.length === 0) {
+    }
+
+    if (spellData.action.damage.length === 0) {
       Hooks.call("DL.UseSpell", {
         sourceToken: new Token(this.token),
         targets,

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -330,11 +330,6 @@ export class DemonlordActor extends Actor {
 
     if (!talentData?.vs?.attribute) {
       await this.activateTalent(talent, true)
-      Hooks.call("DL.UseTalent", {
-        sourceToken: new Token(this.token),
-        targets: [new Token(target.token)],
-        itemId: talent.id,
-      })
     }
     else {
       await this.activateTalent(talent, Boolean(talentData.vs?.damageActive))
@@ -352,6 +347,13 @@ export class DemonlordActor extends Actor {
       let attackRollFormula = '1d20' + plusify(modifier) + (boons ? plusify(boons) + 'd6kh' : '')
       attackRoll = new Roll(attackRollFormula, {})
       attackRoll.evaluate()
+    }
+    if (talentData.vs.damage.length === 0) {
+      Hooks.call("DL.UseTalent", {
+        sourceToken: new Token(this.token),
+        targets: [new Token(target.token)],
+        itemId: talent.id,
+      })
     }
     postTalentToChat(this, talent, attackRoll, target)
   }
@@ -405,7 +407,7 @@ export class DemonlordActor extends Actor {
       const attackFormula = '1d20' + plusify(attackModifier) + (attackBoons ? plusify(attackBoons) + 'd6kh' : '')
       attackRoll = new Roll(attackFormula, {})
       attackRoll.evaluate()
-    } else {
+    } else if (spellData.action.damage.length === 0) {
       Hooks.call("DL.UseSpell", {
         sourceToken: new Token(this.token),
         targets: [new Token(target.token)],

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -234,6 +234,25 @@ export class DemonlordActor extends Actor {
     attackRoll.evaluate()
 
     postAttackToChat(attacker, defender, item, attackRoll, attackAttribute, defenseAttribute)
+
+    const targets = [new Token(defender.token)]
+    const hitTargets = []
+    for (let target of targets) {
+      const targetNumber =
+        defenseAttribute === 'defense'
+          ? defender?.data.data.characteristics.defense
+          : defender?.data.data.attributes[defenseAttribute]?.value || ''
+      if (attackRoll?.total >= targetNumber) {
+        hitTargets.push(target)
+      }
+    }
+
+    Hooks.call("DL.RollAttack", {
+      sourceToken: new Token(attacker.token),
+      targets,
+      itemId: item.id,
+      hitTargets,
+    })
   }
 
   /**

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -328,7 +328,14 @@ export class DemonlordActor extends Actor {
     const target = this.getTarget()
     let attackRoll = null
 
-    if (!talentData?.vs?.attribute) await this.activateTalent(talent, true)
+    if (!talentData?.vs?.attribute) {
+      await this.activateTalent(talent, true)
+      Hooks.call("DL.UseTalent", {
+        sourceToken: new Token(this.token),
+        targets: [new Token(target.token)],
+        itemId: talent.id,
+      })
+    }
     else {
       await this.activateTalent(talent, Boolean(talentData.vs?.damageActive))
 
@@ -398,6 +405,12 @@ export class DemonlordActor extends Actor {
       const attackFormula = '1d20' + plusify(attackModifier) + (attackBoons ? plusify(attackBoons) + 'd6kh' : '')
       attackRoll = new Roll(attackFormula, {})
       attackRoll.evaluate()
+    } else {
+      Hooks.call("DL.UseSpell", {
+        sourceToken: new Token(this.token),
+        targets: [new Token(target.token)],
+        itemId: spell.id,
+      })
     }
 
     postSpellToChat(this, spell, attackRoll, target)

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -352,13 +352,11 @@ export class DemonlordActor extends Actor {
       attackRoll = new Roll(attackRollFormula, {})
       attackRoll.evaluate()
     }
-    if (talentData.vs.damage.length === 0) {
-      Hooks.call("DL.UseTalent", {
-        sourceToken: new Token(this.token),
-        targets,
-        itemId: talent.id,
-      })
-    }
+    Hooks.call("DL.UseTalent", {
+      sourceToken: new Token(this.token),
+      targets,
+      itemId: talent.id,
+    })
     postTalentToChat(this, talent, attackRoll, target?.actor)
   }
 
@@ -414,13 +412,11 @@ export class DemonlordActor extends Actor {
       attackRoll.evaluate()
     }
 
-    if (spellData.action.damage.length === 0) {
-      Hooks.call("DL.UseSpell", {
-        sourceToken: new Token(this.token),
-        targets,
-        itemId: spell.id,
-      })
-    }
+    Hooks.call("DL.UseSpell", {
+      sourceToken: new Token(this.token),
+      targets,
+      itemId: spell.id,
+    })
 
     postSpellToChat(this, spell, attackRoll, target?.actor)
   }

--- a/src/module/chat/chat-listeners.js
+++ b/src/module/chat/chat-listeners.js
@@ -43,8 +43,6 @@ async function _onChatApplyHealing(event) {
     sourceToken,
     targets: selected,
     itemId,
-    event,
-    healing: isFullRate,
   })
 }
 
@@ -59,6 +57,8 @@ async function _onChatRollDamage(event) {
   const item = li.children[0]
   const damageformular = item.dataset.damage
   const damagetype = item.dataset.damagetype
+  const selected = tokenManager.targets
+  const itemId = item.dataset.itemId || li.closest('.demonlord').dataset.itemId
 
   const damageRoll = new Roll(damageformular, {})
   damageRoll.evaluate()
@@ -75,7 +75,7 @@ async function _onChatRollDamage(event) {
   var templateData = {
     actor: actor,
     item: {
-      id: item.dataset.itemId || li.closest('.demonlord').dataset.itemId,
+      id: itemId,
     },
     data: {},
     diceData: formatDice(damageRoll),
@@ -100,6 +100,11 @@ async function _onChatRollDamage(event) {
       chatData.sound = CONFIG.sounds.dice
       ChatMessage.create(chatData)
     }
+  })
+  Hooks.call('DL.RollDamage', {
+    sourceToken: tokenManager.getTokenByActorId(actor.id),
+    targets: selected,
+    itemId,
   })
 }
 
@@ -126,7 +131,6 @@ async function _onChatApplyDamage(event) {
     sourceToken,
     targets: selected,
     itemId,
-    event,
     damage,
   })
 }

--- a/src/module/demonlord.js
+++ b/src/module/demonlord.js
@@ -380,6 +380,12 @@ function loadActorForChatMessage(speaker) {
   return actor
 }
 
+Hooks.on("DL.UseTalent", (data) => {
+  Hooks.call('DL.Action', {type: "use-talent", ...data})
+})
+Hooks.on("DL.UseSpell", (data) => {
+  Hooks.call('DL.Action', {type: "use-spell", ...data})
+})
 Hooks.on('DL.RollAttack', (data) => {
   Hooks.call('DL.Action', {type: "roll-attack", ...data})
 })

--- a/src/module/demonlord.js
+++ b/src/module/demonlord.js
@@ -380,11 +380,17 @@ function loadActorForChatMessage(speaker) {
   return actor
 }
 
-Hooks.on('DL.ApplyDamage', (...args) => {
-  Hooks.call('DL.Action', ...args)
+Hooks.on('DL.RollAttack', (data) => {
+  Hooks.call('DL.Action', {type: "roll-attack", ...data})
 })
-Hooks.on('DL.ApplyHealing', (...args) => {
-  Hooks.call('DL.Action', ...args)
+Hooks.on('DL.RollDamage', (data) => {
+  Hooks.call('DL.Action', {type: "roll-damage", ...data})
+})
+Hooks.on('DL.ApplyDamage', (data) => {
+  Hooks.call('DL.Action', {type: "apply-damage", ...data})
+})
+Hooks.on('DL.ApplyHealing', (data) => {
+  Hooks.call('DL.Action', {type: "apply-healing", ...data})
 })
 
 Hooks.on('DL.Action', () => {

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -28,4 +28,8 @@ export class DemonlordItem extends Item {
    * @private
    */
   async roll() {}
+
+  hasDamage() {
+    return Boolean(this.data.data?.action?.damage || this.data.data?.vs?.damage)
+  }
 }

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -32,4 +32,8 @@ export class DemonlordItem extends Item {
   hasDamage() {
     return Boolean(this.data.data?.action?.damage || this.data.data?.vs?.damage)
   }
+
+  hasHealing() {
+    return this.data.data?.healing?.healing ?? false
+  }
 }

--- a/src/module/item/sheets/base-item-sheet.js
+++ b/src/module/item/sheets/base-item-sheet.js
@@ -77,7 +77,7 @@ export default class DLBaseItemSheet extends ItemSheet {
     if (item.type === 'talent') {
       altdamage.push(updateData?.altdamage)
       altdamagetype.push(updateData?.altdamagetype)
-      updateData['data.vs.damagetypes'] = altdamage.map((damage, index) => ({
+      updateData['data.vs.damagetypes'] = altdamage.filter(Boolean).map((damage, index) => ({
         damage: damage,
         damagetype: altdamagetype[index],
       }))
@@ -86,7 +86,7 @@ export default class DLBaseItemSheet extends ItemSheet {
     } else if (item.type === 'weapon' || item.type === 'spell') {
       altdamage.push(updateData?.altdamage)
       altdamagetype.push(updateData?.altdamagetype)
-      updateData['data.action.damagetypes'] = altdamage.map((damage, index) => ({
+      updateData['data.action.damagetypes'] = altdamage.filter(Boolean).map((damage, index) => ({
         damage: damage,
         damagetype: altdamagetype[index],
       }))


### PR DESCRIPTION
This pull request to add new hooks to automated animations integrations with others minors features/fixes.

- [x] Fix empty damage in chat log when altdamage has an undefined item.
- [x] Replace actor method to get attacker targets to Token Manager. This will add support to the selection token system. Also, this adds support to multi-targeting but I didn't do the user experience changes yet.
- [x] Add hasHealing and hasDamage to check if the item has chat actions in automated animations.