### PR TITLE
Only add rolls to chat message if one was present

### DIFF
--- a/src/module/chat/chat-listeners.js
+++ b/src/module/chat/chat-listeners.js
@@ -89,6 +89,10 @@ async function _onChatRollDamage(event) {
   templateData.data['actorInfo'] = buildActorInfo(actor)
 
   const chatData = getChatBaseData(actor, rollMode)
+  if (damageRoll) {
+    chatData.rolls = [damageRoll],
+    chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
+  }
   const template = 'systems/demonlord/templates/chat/damage.html'
   renderTemplate(template, templateData).then(content => {
     chatData.content = content
@@ -236,6 +240,7 @@ async function _onChatRequestChallengeRoll(event) {
     const template = 'systems/demonlord/templates/chat/makechallengeroll.html'
     renderTemplate(template, templateData).then(content => {
       chatData.content = content
+
       ChatMessage.create(chatData)
     })
   })

--- a/src/module/chat/roll-messages.js
+++ b/src/module/chat/roll-messages.js
@@ -68,8 +68,10 @@ export function postAttackToChat(attacker, defender, item, attackRoll, attackAtt
   data['actorInfo'] = buildActorInfo(attacker)
 
   const chatData = getChatBaseData(attacker, rollMode)
-  chatData.rolls = [attackRoll]
-  chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
+  if (attackRoll) {
+    chatData.rolls = [attackRoll]
+    chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
+  }
   const template = 'systems/demonlord/templates/chat/combat.html'
 
   renderTemplate(template, templateData).then(content => {
@@ -126,8 +128,10 @@ export function postAttributeToChat(actor, attribute, challengeRoll) {
   data['actorInfo'] = buildActorInfo(actor)
 
   const chatData = getChatBaseData(actor, rollMode)
-  chatData.rolls = [challengeRoll]
-  chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
+  if (challengeRoll) {
+    chatData.rolls = [challengeRoll]
+    chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
+  }
   const template = 'systems/demonlord/templates/chat/challenge.html'
   renderTemplate(template, templateData).then(content => {
     chatData.content = content
@@ -230,8 +234,10 @@ export function postTalentToChat(actor, talent, attackRoll, target) {
   data['actorInfo'] = buildActorInfo(actor)
 
   const chatData = getChatBaseData(actor, rollMode)
-  chatData.rolls = [attackRoll]
-  chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
+  if (attackRoll) {
+    chatData.rolls = [attackRoll]
+    chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
+  }
   if (talentData?.damage || talentData?.vs?.attribute || (!talentData?.vs?.attribute && !talentData?.damage)) {
     const template = 'systems/demonlord/templates/chat/talent.html'
     return renderTemplate(template, templateData).then(content => {
@@ -358,8 +364,10 @@ export function postSpellToChat(actor, spell, attackRoll, target) {
   data['actorInfo'] = buildActorInfo(actor)
 
   const chatData = getChatBaseData(actor, rollMode)
-  chatData.rolls = [attackRoll]
-  chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
+  if (attackRoll) {
+    chatData.rolls = [attackRoll]
+    chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
+  }
   const template = 'systems/demonlord/templates/chat/spell.html'
   renderTemplate(template, templateData).then(content => {
     chatData.content = content
@@ -405,8 +413,10 @@ export async function postCorruptionToChat(actor, corruptionRoll) {
 
   const rollMode = game.settings.get('core', 'rollMode')
   const chatData = getChatBaseData(actor, rollMode)
-  chatData.rolls = [corruptionRoll]
-  chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
+  if (corruptionRoll) {
+    chatData.rolls = [corruptionRoll]
+    chatData.type = CONST.CHAT_MESSAGE_TYPES.ROLL
+  }
   const template = 'systems/demonlord/templates/chat/corruption.html'
 
   chatData.content = await renderTemplate(template, templateData)


### PR DESCRIPTION
Fixing an console error when `attackRoll` was not present in `postSpellToChat`. Added to other chat messages for safety.