### PR TITLE
Bugfixes

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -287,7 +287,7 @@
   "DL.ChallengeRequestRollText": "Request Challenge Roll",
   "DL.ChallengeVS": "VS",
   "DL.AttackRollText": "Attack:",
-  "DL.AttackSpecialRollText": "Special Attack:",
+  "DL.AttackSpecialRollText": "Sp. Attack:",
   "DL.AttackRollAttackText": "ATTACK",
   "DL.AttackRollDamageText": "DAMAGE",
   "DL.AttackRollVS": "VS",

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -165,7 +165,7 @@ export class DemonlordActor extends Actor {
       system.characteristics.insanity.max += system.attributes.will.value
 
       // Armor
-      system.characteristics.defense = (system.bonuses.armor.fixed || system.attributes.agility.value + system.bonuses.armor.agility) + system.characteristics.defense
+      system.characteristics.defense = (system.bonuses.armor.fixed || system.attributes.agility.value + system.bonuses.armor.agility) // + system.characteristics.defense // Applied as ActiveEffect further down
     }
     // --- Creature specific data ---
     else {

--- a/src/module/chat/roll-messages.js
+++ b/src/module/chat/roll-messages.js
@@ -189,6 +189,7 @@ export function postTalentToChat(actor, talent, attackRoll, target) {
 
   const attackAttribute = talentData.vs?.attribute?.toLowerCase() || ''
   const defenseAttribute = talentData.vs?.against?.toLowerCase() || ''
+  const savingAttribute = talentData?.action?.defense?.toLowerCase() || ''
   const talentEffects = buildTalentEffectsMessage(actor, talent)
   //
   const templateData = {
@@ -207,7 +208,7 @@ export function postTalentToChat(actor, talent, attackRoll, target) {
   data['didHit'] = attackRoll?.total >= targetNumber
   data['attack'] = attackAttribute ? game.i18n.localize(CONFIG.DL.attributes[attackAttribute]?.toUpperCase()) : ''
   data['against'] = defenseAttribute
-    ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) || ''
+    ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase())
     : ''
   data['againstNumber'] = againstNumber
   data['againstNumberGM'] = againstNumber === '?' ? targetNumber : againstNumber
@@ -217,8 +218,15 @@ export function postTalentToChat(actor, talent, attackRoll, target) {
   data['damageType'] =
     talentData?.vs?.damageactive && talentData?.vs?.damage ? talentData?.vs?.damagetype : talentData?.action?.damagetype
   data['damageTypes'] = talentData?.vs?.damagetypes
-  data['damageExtra20plusFormular'] = talentData?.action?.plus20
+  data['damageExtra20plusFormular'] = talentData?.action?.plus20damage
   data['description'] = talentData?.description
+  data['defense'] = talentData?.action?.defense
+  data['defenseboonsbanse'] = parseInt(talentData?.action?.defenseboonsbanes)
+  data['challStrength'] = savingAttribute === 'strength'
+  data['challAgility'] = savingAttribute === 'agility'
+  data['challIntellect'] = savingAttribute === 'intellect'
+  data['challWill'] = savingAttribute === 'will'
+  data['challPerception'] = savingAttribute === 'perception'
   data['uses'] = usesText
   data['healing'] =
     talentData?.healing?.healactive && talentData?.healing?.healing ? talentData?.healing?.healing : false

--- a/src/module/chat/roll-messages.js
+++ b/src/module/chat/roll-messages.js
@@ -209,7 +209,7 @@ export function postTalentToChat(actor, talent, attackRoll, target) {
   data['damageExtra20plusFormular'] = talentData?.action?.plus20damage
   data['description'] = talentData?.description
   data['defense'] = talentData?.action?.defense
-  data['defenseboonsbanse'] = parseInt(talentData?.action?.defenseboonsbanes)
+  data['defenseboonsbanes'] = parseInt(talentData?.action?.defenseboonsbanes)
   data['challStrength'] = savingAttribute === 'strength'
   data['challAgility'] = savingAttribute === 'agility'
   data['challIntellect'] = savingAttribute === 'intellect'

--- a/src/module/chat/roll-messages.js
+++ b/src/module/chat/roll-messages.js
@@ -76,14 +76,8 @@ export function postAttackToChat(attacker, defender, item, attackRoll, attackAtt
 
   renderTemplate(template, templateData).then(content => {
     chatData.content = content
-    if (game.dice3d && attackRoll && !(attacker.type === 'creature' && !attackShow))
-      game.dice3d
-        .showForRoll(attackRoll, game.user, true, chatData.whisper, chatData.blind)
-        .then(() => ChatMessage.create(chatData))
-    else {
-      chatData.sound = CONFIG.sounds.dice
-      ChatMessage.create(chatData)
-    }
+    chatData.sound = CONFIG.sounds.dice
+    ChatMessage.create(chatData)
   })
 }
 
@@ -135,14 +129,8 @@ export function postAttributeToChat(actor, attribute, challengeRoll) {
   const template = 'systems/demonlord/templates/chat/challenge.html'
   renderTemplate(template, templateData).then(content => {
     chatData.content = content
-    if (game.dice3d) {
-      game.dice3d
-        .showForRoll(challengeRoll, game.user, true, chatData.whisper, chatData.blind)
-        .then(() => ChatMessage.create(chatData))
-    } else {
-      chatData.sound = CONFIG.sounds.dice
-      ChatMessage.create(chatData)
-    }
+    chatData.sound = CONFIG.sounds.dice
+    ChatMessage.create(chatData)
   })
 }
 
@@ -250,21 +238,10 @@ export function postTalentToChat(actor, talent, attackRoll, target) {
     const template = 'systems/demonlord/templates/chat/talent.html'
     return renderTemplate(template, templateData).then(content => {
       chatData.content = content
-      if (game.dice3d && attackRoll != null) {
-        if (actor.type === 'creature' && !game.settings.get('demonlord', 'attackShowAttack')) {
-          if (attackRoll != null) chatData.sound = CONFIG.sounds.dice
-          ChatMessage.create(chatData)
-        } else {
-          game.dice3d
-            .showForRoll(attackRoll, game.user, true, chatData.whisper, chatData.blind)
-            .then(() => ChatMessage.create(chatData))
-        }
-      } else {
-        if (attackRoll != null) {
-          chatData.sound = CONFIG.sounds.dice
-        }
-        ChatMessage.create(chatData)
+      if (attackRoll != null) {
+        chatData.sound = CONFIG.sounds.dice
       }
+      ChatMessage.create(chatData)
     })
   }
 }
@@ -379,21 +356,10 @@ export function postSpellToChat(actor, spell, attackRoll, target) {
   const template = 'systems/demonlord/templates/chat/spell.html'
   renderTemplate(template, templateData).then(content => {
     chatData.content = content
-    if (game.dice3d && attackRoll != null && attackAttribute) {
-      if (actor.type === 'creature' && !game.settings.get('demonlord', 'attackShowAttack')) {
-        if (attackRoll != null) chatData.sound = CONFIG.sounds.dice
-        ChatMessage.create(chatData)
-      } else {
-        game.dice3d
-          .showForRoll(attackRoll, game.user, true, chatData.whisper, chatData.blind)
-          .then(() => ChatMessage.create(chatData))
-      }
-    } else {
-      if (attackRoll != null && attackAttribute) {
-        chatData.sound = CONFIG.sounds.dice
-      }
-      ChatMessage.create(chatData)
+    if (attackRoll != null && attackAttribute) {
+      chatData.sound = CONFIG.sounds.dice
     }
+    ChatMessage.create(chatData)
   })
 }
 
@@ -428,11 +394,7 @@ export async function postCorruptionToChat(actor, corruptionRoll) {
   const template = 'systems/demonlord/templates/chat/corruption.html'
 
   chatData.content = await renderTemplate(template, templateData)
-  if (game.dice3d) {
-    await game.dice3d.showForRoll(corruptionRoll, game.user, true, chatData.whisper, chatData.blind)
-  } else {
-    chatData.sound = CONFIG.sounds.dice
-  }
+  chatData.sound = CONFIG.sounds.dice
   await ChatMessage.create(chatData)
 
   // Get mark of darkess if roll < corruption value

--- a/src/templates/chat/spell.html
+++ b/src/templates/chat/spell.html
@@ -269,53 +269,99 @@
       </div>
     {{/if}}
   </div>
-  {{#if data.ifBlindedRoll }}
-  <div class="gmonly">
-  {{/if}}
-  {{#if data.hasAreaTarget }}
-    <div class="combatactions place-template dl-clickable" data-item-uuid="{{item.uuid}}">
-      <div class="header">
-        <img src="systems/demonlord/assets/ui/icons/pentagram.webp" width="15" height="15"/>
-        <div>{{localize "DL.ActionPlaceTemplate"}}</div>
-      </div>
+  {{#if data.isCreature}}
+    <div class="gmonly">
+      {{#if data.hasAreaTarget }}
+        <div class="combatactions place-template dl-clickable" data-item-uuid="{{item.uuid}}">
+          <div class="header">
+            <img src="systems/demonlord/assets/ui/icons/pentagram.webp" width="15" height="15"/>
+            <div>{{localize "DL.ActionPlaceTemplate"}}</div>
+          </div>
+        </div>
+      {{/if}}
+      {{#if data.damageFormular}}
+        <div class="combatactions roll-damage">
+          <div class="header" data-item-id="{{data._id}}" data-damage="{{data.damageFormular}}"
+              data-damagetype="{{data.damageType}}">
+            <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15"/>
+            <div>{{data.damageType}} {{localize "DL.WeaponDamage"}} ({{data.damageFormular}})</div>
+          </div>
+        </div>
+      {{/if}}
+      {{#each data.damageTypes as |damagetype id|}}
+        <div class="combatactions roll-damage">
+          <div class="header" data-item-id="{{data._id}}" data-damage="{{damagetype.damage}}"
+              data-damagetype="{{damagetype.damagetype}}">
+            <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15"/>
+            <div>{{damagetype.damagetype}} {{localize "DL.WeaponDamage"}} ({{damagetype.damage}})</div>
+          </div>
+        </div>
+      {{/each}}
+      {{#if data.damageExtra20plusFormular}}
+        <div class="combatactions roll-damage">
+          <div class="header" data-item-id="{{data._id}}" data-damage="{{data.damageExtra20plusFormular}}">
+            <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15"/>
+            <div>{{localize "DL.TalentExtraDamage20plus"}} ({{data.damageExtra20plusFormular}})</div>
+          </div>
+        </div>
+      {{/if}}
+      {{#each data.itemEffects as |effect|}}
+        <div class="combatactions apply-effect" data-effect-uuid="{{effect.uuid}}">
+          <div class="header">
+            <img src="{{effect.icon}}" width="15" height="15"/>
+            <div>{{effect.label}}</div>
+          </div>
+        </div>
+      {{/each}}
     </div>
-  {{/if}}
-
-  {{#if data.damageFormular}}
-    <div class="combatactions roll-damage">
-      <div class="header" data-item-id="{{data._id}}" data-damage="{{data.damageFormular}}"
-           data-damagetype="{{data.damageType}}">
-        <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15"/>
-        <div>{{data.damageType}} {{localize "DL.WeaponDamage"}} ({{data.damageFormular}})</div>
+  {{else}}
+    {{#if data.ifBlindedRoll }}
+    <div class="gmonly">
+    {{/if}}
+    {{#if data.hasAreaTarget }}
+      <div class="combatactions place-template dl-clickable" data-item-uuid="{{item.uuid}}">
+        <div class="header">
+          <img src="systems/demonlord/assets/ui/icons/pentagram.webp" width="15" height="15"/>
+          <div>{{localize "DL.ActionPlaceTemplate"}}</div>
+        </div>
       </div>
-    </div>
-  {{/if}}
-  {{#each data.damageTypes as |damagetype id|}}
-    <div class="combatactions roll-damage">
-      <div class="header" data-item-id="{{data._id}}" data-damage="{{damagetype.damage}}"
-           data-damagetype="{{damagetype.damagetype}}">
-        <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15"/>
-        <div>{{damagetype.damagetype}} {{localize "DL.WeaponDamage"}} ({{damagetype.damage}})</div>
+    {{/if}}
+    {{#if data.damageFormular}}
+      <div class="combatactions roll-damage">
+        <div class="header" data-item-id="{{data._id}}" data-damage="{{data.damageFormular}}"
+            data-damagetype="{{data.damageType}}">
+          <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15"/>
+          <div>{{data.damageType}} {{localize "DL.WeaponDamage"}} ({{data.damageFormular}})</div>
+        </div>
       </div>
-    </div>
-  {{/each}}
-  {{#if data.damageExtra20plusFormular}}
-    <div class="combatactions roll-damage">
-      <div class="header" data-item-id="{{data._id}}" data-damage="{{data.damageExtra20plusFormular}}">
-        <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15"/>
-        <div>{{localize "DL.TalentExtraDamage20plus"}} ({{data.damageExtra20plusFormular}})</div>
+    {{/if}}
+    {{#each data.damageTypes as |damagetype id|}}
+      <div class="combatactions roll-damage">
+        <div class="header" data-item-id="{{data._id}}" data-damage="{{damagetype.damage}}"
+            data-damagetype="{{damagetype.damagetype}}">
+          <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15"/>
+          <div>{{damagetype.damagetype}} {{localize "DL.WeaponDamage"}} ({{damagetype.damage}})</div>
+        </div>
       </div>
-    </div>
-  {{/if}}
-  {{#each data.itemEffects as |effect|}}
-    <div class="combatactions apply-effect" data-effect-uuid="{{effect.uuid}}">
-      <div class="header">
-        <img src="{{effect.icon}}" width="15" height="15"/>
-        <div>{{effect.label}}</div>
+    {{/each}}
+    {{#if data.damageExtra20plusFormular}}
+      <div class="combatactions roll-damage">
+        <div class="header" data-item-id="{{data._id}}" data-damage="{{data.damageExtra20plusFormular}}">
+          <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15"/>
+          <div>{{localize "DL.TalentExtraDamage20plus"}} ({{data.damageExtra20plusFormular}})</div>
+        </div>
       </div>
+    {{/if}}
+    {{#each data.itemEffects as |effect|}}
+      <div class="combatactions apply-effect" data-effect-uuid="{{effect.uuid}}">
+        <div class="header">
+          <img src="{{effect.icon}}" width="15" height="15"/>
+          <div>{{effect.label}}</div>
+        </div>
+      </div>
+    {{/each}}
+    {{#if data.ifBlindedRoll }}
     </div>
-  {{/each}}
-  {{#if data.ifBlindedRoll }}
-  </div>
+    {{/if}}
   {{/if}}
 </div>

--- a/src/templates/chat/talent.html
+++ b/src/templates/chat/talent.html
@@ -115,73 +115,44 @@
       {{/if}}
     </div>
   {{/if}}
+  {{#if data.isCreature}}
+    <div class="gmonly">
+  {{/if}}
   {{#if data.attackEffects}}
-    {{#if data.isCreature}}
-      <div class="gmonly">
-        <div class="description">
-          <div class="header">{{localize "DL.AttackRollBonuses"}}</div>
-          <div class="body">{{{data.attackEffects}}}
-            <hr>
-          </div>
-        </div>
+    <div class="description">
+      <div class="header">{{localize "DL.AttackRollBonuses"}}:</div>
+      <div class="body">{{{data.attackEffects}}}
+        <hr>
       </div>
-    {{else}}
-      <div class="description">
-        <div class="header">{{localize "DL.AttackRollBonuses"}}</div>
-        <div class="body">{{{data.attackEffects}}}
-          <hr>
-        </div>
-      </div>
-    {{/if}}
+    </div>
   {{/if}}
   {{#if data.description}}
-    {{#if data.isCreature}}
-      <div class="gmonly">
-        <div class="description">
-          <div class="header">{{localize "DL.AttackRollDescription"}}</div>
-          <div class="body">{{{data.description}}}</div>
-        </div>
-      </div>
-    {{else}}
-      <div class="description">
-        <div class="header">{{localize "DL.AttackRollDescription"}}</div>
-        <div class="body">{{{data.description}}}</div>
-      </div>
-    {{/if}}
+    <div class="description">
+      <div class="header">{{localize "DL.AttackRollDescription"}}</div>
+      <div class="body">{{{data.description}}}</div>
+    </div>
   {{/if}}
   {{#if data.talentEffects}}
-    {{#if data.isCreature}}
-      <div class="gmonly">
-        <div class="description">
-          <div class="header">{{localize "DL.TalentRollEffects"}}</div>
-          <div class="body">{{{data.talentEffects}}}
-            <hr>
-          </div>
-        </div>
+    <div class="description">
+      <div class="header">{{localize "DL.TalentRollEffects"}}</div>
+      <div class="body">{{{data.talentEffects}}}
+        <hr>
       </div>
-    {{else}}
-      <div class="description">
-        <div class="header">{{localize "DL.TalentRollEffects"}}</div>
-        <div class="body">{{{data.talentEffects}}}
-          <hr>
-        </div>
-      </div>
-    {{/if}}
+    </div>
   {{/if}}
   {{#if item.system.action.extraeffect}}
-    {{#if data.isCreature}}
-      <div class="gmonly">
-        <div class="description">
-          <div class="header">{{localize "DL.TalentExtraEffect"}}</div>
-          <div class="body">{{{item.system.action.extraeffect}}}</div>
-        </div>
+    <div class="description">
+      <div class="header">{{localize "DL.TalentExtraEffect"}}</div>
+      <div class="body">{{{item.system.action.extraeffect}}}</div>
+    </div>
+  {{/if}}
+  {{#if data.defense}}
+    <div class="roll20">
+      <div class="header">{{localize "DL.SpellTypeDefense"}}</div>
+      <div class="body">{{localize "DL.ChallengeRoll"}}: {{data.defense}}
+        {{#if data.defenseboonsbanes}}({{data.defenseboonsbanes}}){{/if}}
       </div>
-    {{else}}
-      <div class="description">
-        <div class="header">{{localize "DL.TalentExtraEffect"}}</div>
-        <div class="body">{{{item.system.action.extraeffect}}}</div>
-      </div>
-    {{/if}}
+    </div>
   {{/if}}
   {{#if data.healing}}
     <div class="talentactions roll-healing">
@@ -197,6 +168,61 @@
       </div>
     </div>
   {{/if}}
+  {{#if data.isCreature}}
+  </div>
+  {{/if}}
+  <div class="gmonly">
+    {{#if data.challStrength}}
+      <div class="challengeaction request-challengeroll">
+        <div class="header" data-attribute="Strength" data-boba="{{data.defenseboonsbanes}}">
+          <div class="challenge-img"></div>
+          <div>{{localize "DL.ChallengeRoll"}}: {{localize "DL.AttributeStrength"}}
+            {{#if data.defenseboonsbanes}}({{data.defenseboonsbanes}}){{/if}}
+          </div>
+        </div>
+      </div>
+    {{/if}}
+    {{#if data.challAgility}}
+      <div class="challengeaction request-challengeroll">
+        <div class="header" data-attribute="Agility" data-boba="{{data.defenseboonsbanes}}">
+          <div class="challenge-img"></div>
+          <div>{{localize "DL.ChallengeRoll"}}: {{localize "DL.AttributeAgility"}}
+            {{#if data.defenseboonsbanes}}({{data.defenseboonsbanes}}){{/if}}
+          </div>
+        </div>
+      </div>
+    {{/if}}
+    {{#if data.challIntellect}}
+      <div class="challengeaction request-challengeroll">
+        <div class="header" data-attribute="Intellect" data-boba="{{data.defenseboonsbanes}}">
+          <div class="challenge-img"></div>
+          <div>{{localize "DL.ChallengeRoll"}}: {{localize "DL.AttributeIntellect"}}
+            {{#if data.defenseboonsbanes}}({{data.defenseboonsbanes}}){{/if}}
+          </div>
+        </div>
+      </div>
+    {{/if}}
+    {{#if data.challWill}}
+      <div class="challengeaction request-challengeroll">
+        <div class="header" data-attribute="Will" data-boba="{{data.defenseboonsbanes}}">
+          <div class="challenge-img"></div>
+          <div>{{localize "DL.ChallengeRoll"}}: {{localize "DL.AttributeWill"}}
+            {{#if data.defenseboonsbanes}}({{data.defenseboonsbanes}}){{/if}}
+          </div>
+        </div>
+      </div>
+    {{/if}}
+    {{#if data.challPerception}}
+      <div class="challengeaction request-challengeroll">
+        <div class="header" data-attribute="Perception" data-boba="{{data.defenseboonsbanes}}">
+          <div class="challenge-img"></div>
+          <div>{{localize "DL.ChallengeRoll"}}: {{localize "DL.AttributePerception"}}
+            {{#if data.defenseboonsbanes}}({{data.defenseboonsbanes}}){{/if}}
+          </div>
+        </div>
+      </div>
+    {{/if}}
+  </div>
   {{#if data.isCreature}}
     <div class="gmonly">
       {{#if data.damageFormular}}


### PR DESCRIPTION
Fixes several bugs reported by members of the Discord channel.

- Request Challenge Roll button now appears in Talent rolls
- Extra damage 20 plus works when using both Active Effect and sheet field
- Defense is now only applied once to Defense calculation
- Fixed differences in buttons and sections in Talent and Spell tamplates
- Contracted Special Attack to Sp. Attack to reduce cases where long talent names break formatting (names longer than 29 characters still break the formatting). A proper fix for this requires severe changes to all templates, so we have this instead.