### PR TITLE
Fix for begin combat skipping first combatant

### DIFF
--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -74,7 +74,7 @@ export class DLCombat extends Combat {
     this.combatants.forEach(combatant => this.setInitiative(combatant.id, this.getInitiativeValue(combatant)))
     return await this.update({
       round: 1,
-      turn: 1,
+      turn: 0,
     })
   }
 


### PR DESCRIPTION
[Issue 212](https://github.com/Xacus/demonlord/issues/122) - Tested locally in the latest foundry.