### PR TITLE
Fix for Disable Status Icons option

### DIFF
--- a/src/module/demonlord.js
+++ b/src/module/demonlord.js
@@ -147,6 +147,7 @@ Hooks.once('setup', function () {
   // Regardless of the setting, add the "invisible" status so that actors can turn invisible
   else {
     effects.push(CONFIG.statusEffects.find(e => e.id === 'invisible'))
+    effects.push(CONFIG.statusEffects.find(e => e.id === 'dead'))
   }
 
 


### PR DESCRIPTION
A fix for Disable Status Icons option not allowing damage apply equal or above token health due missing the "dead" condition.
Tested on Foundry V11.313
Did not find any issues related to this fix.