### PR TITLE
updated path for compendium build output

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,7 @@ async function buildCompendium(compendium) {
     compendium = parts.at(-1);
   }
 
-  const command = `fvtt package pack  --type ${packageType} --id ${packageId} -n "${compendium}" --in "${compendiaDirectory}/${compendium}" --out "${distDirectory}/packs/${compendium}"`
+  const command = `fvtt package pack  --type ${packageType} --id ${packageId} -n "${compendium}" --in "${compendiaDirectory}/${compendium}" --out "${distDirectory}/packs/"`
   console.log(cp.execSync(command).toString());
 }
 


### PR DESCRIPTION
One of the two ways to fix the compendiums not having contents in 3.2.0