### PR TITLE
Details are missing on the creature reference screen in some cases

### DIFF
--- a/src/templates/tabs/creature-reference.hbs
+++ b/src/templates/tabs/creature-reference.hbs
@@ -80,7 +80,7 @@
   {{/if}}
 
   <!-- SPECIAL ATTACKS -->
-  {{#if actor.weapons.length}}
+  {{#if actor.talents.length}}
     <div class="dl-creature-section-header">
       {{localize "DL.CreatureSpecialAttacks"}}
     </div>
@@ -94,7 +94,7 @@
   {{/if}}
 
   <!-- SPECIAL ACTIONS -->
-  {{#if actor.weapons.length}}
+  {{#if actor.specialactions.length}}
     <div class="dl-creature-section-header">
       {{localize "DL.CreatureSpecialActions"}}
     </div>
@@ -134,7 +134,7 @@
   {{/if}}
 
   <!-- END OF ROUND -->
-  {{#if actor.weapons.length}}
+  {{#if actor.endoftheround.length}}
     <div class="dl-creature-section-header">
       {{localize "DL.CreatureSpecialEndRound"}}
     </div>


### PR DESCRIPTION
If the creature has no attack option, the following information also not displayed on the creature reference screen
- Special Attacks
- Special Actions
- End of the Round