### PR TITLE
Attack message normalisation

### DIFF
--- a/src/module/active-effects/afflictions.js
+++ b/src/module/active-effects/afflictions.js
@@ -32,7 +32,7 @@ export class DLAfflictions {
     const isBlocked = actor.system.maluses.autoFail[actionType]?.[actionAttribute] > 0
     if (isBlocked) {
       // TODO: more precise message? Currently it picks the first message
-      let msg = actor.getEmbeddedCollection('ActiveEffect').find(effect => Boolean(effect.flags?.warningMessage))
+      let msg = Array.from(actor.allApplicableEffects()).find(effect => Boolean(effect.flags?.warningMessage))
         ?.flags.warningMessage
       msg = msg ?? game.i18n.localize(`DL.AutoFail${actionType.capitalize()}s`)
       ui.notifications.error(msg)
@@ -42,8 +42,7 @@ export class DLAfflictions {
 
   static async clearAfflictions(actor) {
     if (!actor) return
-    const afflictions = actor
-      .getEmbeddedCollection('ActiveEffect')
+    const afflictions = Array.from(actor.allApplicableEffects())
       .filter(e => e.statuses.size > 0)
       .map(e => e._id)
     await actor.deleteEmbeddedDocuments('ActiveEffect', afflictions)

--- a/src/module/active-effects/item-effects.js
+++ b/src/module/active-effects/item-effects.js
@@ -52,7 +52,7 @@ const falsyChangeFilter = change => Boolean(change.value)
 
 export class DLActiveEffects {
   static async removeEffectsByOrigin(doc, originID) {
-    const toDel = doc.getEmbeddedCollection('ActiveEffect').filter(effect => effect.data?.origin?.includes(originID))
+    const toDel = doc.getEmbeddedCollection('ActiveEffect').filter(effect => effect?.origin?.includes(originID))
 
     const promises = []
     for await (const e of toDel) {

--- a/src/module/active-effects/item-effects.js
+++ b/src/module/active-effects/item-effects.js
@@ -1,3 +1,4 @@
+import { DemonlordActor } from '../actor/actor'
 import { plusify } from '../utils/utils'
 
 export const addEffect = (key, value, priority) => ({
@@ -52,7 +53,7 @@ const falsyChangeFilter = change => Boolean(change.value)
 
 export class DLActiveEffects {
   static async removeEffectsByOrigin(doc, originID) {
-    const toDel = doc.getEmbeddedCollection('ActiveEffect').filter(effect => effect?.origin?.includes(originID))
+    const toDel = (doc instanceof DemonlordActor ? Array.from(doc.allApplicableEffects()) : doc.effects).filter(effect => effect?.origin?.includes(originID))
 
     const promises = []
     for await (const e of toDel) {

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -191,23 +191,63 @@ export class DemonlordActor extends Actor {
       if (result !== null) this.overrides[change.key] = result
     }
 
-    // WIP: Adjust size here
-    // for (let change of effectChanges.filter(e => e.key.includes("size"))) {
-    //   let size = change.value
-    //   let newSize = 0
+    // Adjust size here
+    const originalSize = this.data._source.system.characteristics.size
+    let modifiedSize = 0
+    let newSize = "1"
+    if (originalSize.includes("/")) {
+      const [numerator, denominator] = originalSize.split("/")
+      modifiedSize = parseInt(numerator) / parseInt(denominator)
+    } else {
+      modifiedSize = parseInt(originalSize)
+    }
+    for (let change of effectChanges.filter(e => e.key.includes("size"))) {
+      let sizeMod = 0
 
-    //   if (size.includes("/")) {
-    //     const [numerator, denominator] = size.split("/")
-    //     newSize = parseInt(numerator) / parseInt(denominator)
-    //   } else {
-    //     newSize = parseInt(size)
-    //   }
+      if (change.value.includes("/")) {
+        const [numerator, denominator] = change.value.split("/")
+        sizeMod = parseInt(numerator) / parseInt(denominator)
+      } else {
+        sizeMod = parseInt(change.value)
+      }
 
-    //   change.value = newSize.toString()
+      switch (change.mode) {
+        case 0: // CUSTOM
+          break
+        case 1: // MULTIPLY
+          modifiedSize *= sizeMod
+          break
+        case 2: // ADD
+          modifiedSize += sizeMod
+          break
+        case 3: // DOWNGRADE
+          modifiedSize = Math.min(modifiedSize, sizeMod)
+          break
+        case 4: // UPGRADE
+          modifiedSize = Math.max(modifiedSize, sizeMod)
+          break
+        case 5: // OVERRIDE
+          modifiedSize = sizeMod
+          break
+      }
 
-    //   const result = change.effect.apply(this, change)
-    //   if (result !== null) this.overrides[change.key] = result
-    // }
+      // Calculate string if fraction
+      if (modifiedSize >= 1) {
+        newSize = Math.floor(modifiedSize).toString()
+      } else if (modifiedSize >= 0.5) {
+        newSize = "1/2";
+      } else if (modifiedSize >= 0.25) {
+        newSize = "1/4";
+      } else if (modifiedSize >= 0.125) {
+        newSize = "1/8";
+      } else if (modifiedSize >= 0.0625) {
+        newSize = "1/16";
+      } else if (modifiedSize >= 0.03125) {
+        newSize = "1/32";
+      }
+    }
+
+    this.system.characteristics.size = newSize
   }
 
   /* -------------------------------------------- */

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -129,7 +129,7 @@ export class DemonlordActor extends Actor {
 
     // We can reapply some active effects if we know they happened
     // We're copying what it's done in applyActiveEffects
-    const effectChanges = this.effects.reduce((changes, e) => {
+    const effectChanges = Array.from(this.allApplicableEffects()).reduce((changes, e) => {
       if (e.disabled || e.isSuppressed) return changes
       return changes.concat(e.changes.map(c => {
         c = foundry.utils.duplicate(c)

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -192,7 +192,7 @@ export class DemonlordActor extends Actor {
     }
 
     // Adjust size here
-    const originalSize = this.data._source.system.characteristics.size
+    const originalSize = this._source.system.characteristics.size
     let modifiedSize = 0
     let newSize = "1"
     if (originalSize.includes("/")) {
@@ -760,14 +760,14 @@ export class DemonlordActor extends Actor {
     let uses = talent.system.uses?.value || 0
     const usesmax = talent.system.uses?.max || 0
     if (usesmax > 0 && uses < usesmax)
-      return await talent.update({'data.uses.value': ++uses, 'data.addtonextroll': setActive}, {parent: this})
+      return await talent.update({'system.uses.value': ++uses, 'system.addtonextroll': setActive}, {parent: this})
   }
 
   async deactivateTalent(talent, decrement = 0, onlyTemporary = false) {
     if (onlyTemporary && !talent.system.uses?.max) return
     let uses = talent.system.uses?.value || 0
     uses = Math.max(0, uses - decrement)
-    return await talent.update({'data.uses.value': uses, 'data.addtonextroll': false}, {parent: this})
+    return await talent.update({'system.uses.value': uses, 'system.addtonextroll': false}, {parent: this})
   }
 
   /* -------------------------------------------- */
@@ -776,15 +776,15 @@ export class DemonlordActor extends Actor {
     await Promise.all(game.user.targets.map(async target => {
       const currentDamage = parseInt(target.actor.system.characteristics.health.value)
       await target?.actor.update({
-        'data.characteristics.health.value': currentDamage + damage,
+        'system.characteristics.health.value': currentDamage + damage,
       })
     }))
   }
 
   async restActor() {
     // Reset talent and spell uses
-    const talentData = this.items.filter(i => i.type === 'talent').map(t => ({_id: t.id, 'data.uses.value': 0}))
-    const spellData = this.items.filter(i => i.type === 'spell').map(s => ({_id: s.id, 'data.castings.value': 0}))
+    const talentData = this.items.filter(i => i.type === 'talent').map(t => ({_id: t.id, 'system.uses.value': 0}))
+    const spellData = this.items.filter(i => i.type === 'spell').map(s => ({_id: s.id, 'system.castings.value': 0}))
 
     await this.updateEmbeddedDocuments('Item', [...talentData, ...spellData])
     await this.applyHealing(true)
@@ -826,7 +826,7 @@ export class DemonlordActor extends Actor {
     }
 
     return this.update({
-      'data.characteristics.health.value': newHp
+      'system.characteristics.health.value': newHp
     })
   }
 
@@ -841,7 +841,7 @@ export class DemonlordActor extends Actor {
         const rank = s.system.rank
         const currentMax = s.system.castings.max
         const newMax = CONFIG.DL.spelluses[power]?.[rank] ?? 0
-        if (currentMax !== newMax) diff.push({_id: s.id, 'data.castings.max': newMax})
+        if (currentMax !== newMax) diff.push({_id: s.id, 'system.castings.max': newMax})
       })
     if (diff.length > 0) return await this.updateEmbeddedDocuments('Item', diff)
   }

--- a/src/module/actor/sheets/base-actor-sheet.js
+++ b/src/module/actor/sheets/base-actor-sheet.js
@@ -242,7 +242,7 @@ export default class DLBaseActorSheet extends ActorSheet {
       }
       if (['action', 'afflictions', 'damage'].includes(div.dataset.type)) {
         const type = capitalize(div.dataset.type)
-        const k = 'data.afflictionsTab.hideAction' + type
+        const k = 'system.afflictionsTab.hideAction' + type
         const v = !this.actor.system.afflictionsTab[`hide${type}`]
         await this.actor.update({[k]: v})
       }
@@ -279,7 +279,7 @@ export default class DLBaseActorSheet extends ActorSheet {
     const _itemwear = async (ev, bool) => {
       const id = $(ev.currentTarget).closest('[data-item-id]').data('itemId')
       const item = this.actor.items.get(id)
-      await item.update({'data.wear': bool}, {parent: this.actor})
+      await item.update({'system.wear': bool}, {parent: this.actor})
     }
     html.find('.item-wear').click(async ev => await _itemwear(ev, false))
     html.find('.item-wearoff').click(async ev => await _itemwear(ev, true))
@@ -314,7 +314,7 @@ export default class DLBaseActorSheet extends ActorSheet {
       const usesmax = +item.system.castings.max
       if (ev.button == 0) uses = uses < usesmax ? uses + 1 : 0
       else if (ev.button == 2) uses = uses > 0 ? uses - 1 : 0
-      await item.update({'data.castings.value': uses}, {parent: this.actor})
+      await item.update({'system.castings.value': uses}, {parent: this.actor})
     })
 
     // Rollable Attributes

--- a/src/module/actor/sheets/base-actor-sheet.js
+++ b/src/module/actor/sheets/base-actor-sheet.js
@@ -29,7 +29,7 @@ export default class DLBaseActorSheet extends ActorSheet {
       actor: this.actor,
       system: this.actor.system,
       effects: true,
-      generalEffects: prepareActiveEffectCategories(this.actor.effects, true),
+      generalEffects: prepareActiveEffectCategories(Array.from(this.actor.allApplicableEffects()), true),
       effectsOverview: buildOverview(this.actor),
       flags: this.actor.flags,
     }
@@ -60,7 +60,7 @@ export default class DLBaseActorSheet extends ActorSheet {
     const actorData = sheetData.actor
 
     const actorHasChangeBool = (actor, key) => {
-      return actor.getEmbeddedCollection('ActiveEffect').filter(e => !e.disabled && e.changes.filter(c => c.key === key && c.value === '1').length > 0).length > 0
+      return Array.from(actor.allApplicableEffects()).filter(e => !e.disabled && e.changes.filter(c => c.key === key && c.value === '1').length > 0).length > 0
     }
 
     const noAttacks = actorHasChangeBool(actorData, 'system.maluses.noAttacks')

--- a/src/module/actor/sheets/character-sheet.js
+++ b/src/module/actor/sheets/character-sheet.js
@@ -41,29 +41,29 @@ export default class DLCharacterSheet extends DLBaseActorSheet {
 
     // Effects categories
     data.ancestryEffects = prepareActiveEffectCategories(
-      this.actor.effects.filter(effect => effect.flags?.sourceType === 'ancestry'),
+      Array.from(this.actor.allApplicableEffects()).filter(effect => effect.flags?.sourceType === 'ancestry'),
     )
     delete data.ancestryEffects.temporary
 
     data.pathEffects = prepareActiveEffectCategories(
-      this.actor.effects.filter(effect => effect.flags?.sourceType === 'path'),
+      Array.from(this.actor.allApplicableEffects()).filter(effect => effect.flags?.sourceType === 'path'),
     )
     delete data.pathEffects.temporary
 
     data.talentEffects = prepareActiveEffectCategories(
-      this.actor.effects.filter(effect => effect.flags?.sourceType === 'talent'),
+      Array.from(this.actor.allApplicableEffects()).filter(effect => effect.flags?.sourceType === 'talent'),
     )
     data.spellEffects = prepareActiveEffectCategories(
-      this.actor.effects.filter(effect => effect.flags?.sourceType === 'spell'),
+      Array.from(this.actor.allApplicableEffects()).filter(effect => effect.flags?.sourceType === 'spell'),
     )
     data.itemEffects = prepareActiveEffectCategories(
-      this.actor.effects.filter(effect => ['armor', 'weapon', 'item'].indexOf(effect.flags?.sourceType) >= 0),
+      Array.from(this.actor.allApplicableEffects()).filter(effect => ['armor', 'weapon', 'item'].indexOf(effect.flags?.sourceType) >= 0),
     )
     data.itemEffects = prepareActiveEffectCategories(
-      this.actor.effects.filter(effect => effect.flags?.sourceType === 'creaturerole'),
+      Array.from(this.actor.allApplicableEffects()).filter(effect => effect.flags?.sourceType === 'creaturerole'),
     )
     data.itemEffects = prepareActiveEffectCategories(
-      this.actor.effects.filter(effect => effect.flags?.sourceType === 'relic'),
+      Array.from(this.actor.allApplicableEffects()).filter(effect => effect.flags?.sourceType === 'relic'),
     )
     this.prepareItems(data)
     return data

--- a/src/module/actor/sheets/character-sheet.js
+++ b/src/module/actor/sheets/character-sheet.js
@@ -179,7 +179,7 @@ export default class DLCharacterSheet extends DLBaseActorSheet {
 
       await actor
         .update({
-          'data.characteristics.editbar': actor.system.characteristics.editbar,
+          'system.characteristics.editbar': actor.system.characteristics.editbar,
         })
         .then(_ => this.render())
     })
@@ -202,7 +202,7 @@ export default class DLCharacterSheet extends DLBaseActorSheet {
         if (value <= 0) value = 0
         else value--
       }
-      await this.actor.update({ 'data.characteristics.insanity.value': value }).then(_ => this.render())
+      await this.actor.update({ 'system.characteristics.insanity.value': value }).then(_ => this.render())
     })
 
     // Corruption bar click
@@ -216,7 +216,7 @@ export default class DLCharacterSheet extends DLBaseActorSheet {
         if (value <= 0) value = 0
         else value--
       }
-      await this.actor.update({ 'data.characteristics.corruption.value': value }).then(_ => this.render())
+      await this.actor.update({ 'system.characteristics.corruption.value': value }).then(_ => this.render())
     })
 
     // Health bar fill
@@ -281,7 +281,7 @@ export default class DLCharacterSheet extends DLBaseActorSheet {
     html
       .find('.religion-edit')
       .click(async _ =>
-        await this.actor.update({ 'data.religion.edit': !this.actor.system.religion.edit }).then(() => this.render()),
+        await this.actor.update({ 'system.religion.edit': !this.actor.system.religion.edit }).then(() => this.render()),
       )
 
     // Ammo uses

--- a/src/module/actor/sheets/creature-sheet.js
+++ b/src/module/actor/sheets/creature-sheet.js
@@ -38,7 +38,7 @@ export default class DLCreatureSheet extends DLBaseActorSheet {
     const actorData = sheetData.actor
 
     const actorHasChangeBool = (actor, key) => {
-      return actor.getEmbeddedCollection('ActiveEffect').filter(e => !e.disabled && e.changes.filter(c => c.key === key && c.value === '1').length > 0).length > 0
+      return Array.from(actor.allApplicableEffects()).filter(e => !e.disabled && e.changes.filter(c => c.key === key && c.value === '1').length > 0).length > 0
     }
 
     const noSpecialAttacks = actorHasChangeBool(actorData, 'system.maluses.noSpecialAttacks')

--- a/src/module/chat/effect-messages.js
+++ b/src/module/chat/effect-messages.js
@@ -63,7 +63,7 @@ const changeListToMsg = (m, keys, title, f=plusify) => {
  * @returns {*}
  */
 export function buildAttackEffectsMessage(attacker, defender, item, attackAttribute, defenseAttribute, inputBoons, plus20) {
-  const attackerEffects = attacker.getEmbeddedCollection('ActiveEffect').filter(effect => !effect.disabled)
+  const attackerEffects = Array.from(attacker.allApplicableEffects()).filter(effect => !effect.disabled)
   let m = _remapEffects(attackerEffects)
 
   let defenderBoons = (defender?.system.bonuses.defense.boons[defenseAttribute] || 0) + (defender?.system.bonuses.defense.boons.all || 0)
@@ -119,7 +119,7 @@ export function buildAttackEffectsMessage(attacker, defender, item, attackAttrib
  * @returns {string}
  */
 export function buildAttributeEffectsMessage(actor, attribute, inputBoons) {
-  const actorEffects = actor?.getEmbeddedCollection('ActiveEffect').filter(effect => !effect.disabled)
+  const actorEffects = Array.from(actor.allApplicableEffects()).filter(effect => !effect.disabled)
   let m = _remapEffects(actorEffects)
   let inputBoonsMsg = inputBoons ? _toMsg(game.i18n.localize('DL.DialogInput'), plusify(inputBoons)) : ''
   let result = ''
@@ -137,7 +137,7 @@ export function buildAttributeEffectsMessage(actor, attribute, inputBoons) {
  * @returns {string}
  */
 export function buildTalentEffectsMessage(actor, talent) {
-  const effects = actor.getEmbeddedCollection('ActiveEffect').filter(effect => effect.origin === talent.uuid)
+  const effects = Array.from(actor.allApplicableEffects()).filter(effect => effect.origin === talent.uuid)
 
   let m = _remapEffects(effects)
   const get = (key, strLocalization, prefix = '') => {
@@ -174,7 +174,7 @@ export function buildTalentEffectsMessage(actor, talent) {
 /* -------------------------------------------- */
 
 export function buildOverview(actor) {
-  let m = _remapEffects(actor.effects.filter(e => !e.disabled)) // <changeKey> : [{label, type, value}, ]
+  let m = _remapEffects(Array.from(actor.allApplicableEffects()).filter(e => !e.disabled)) // <changeKey> : [{label, type, value}, ]
   m.delete('')
   const sections = []
 

--- a/src/module/chat/effect-messages.js
+++ b/src/module/chat/effect-messages.js
@@ -62,7 +62,7 @@ const changeListToMsg = (m, keys, title, f=plusify) => {
  * @param defenseAttribute
  * @returns {*}
  */
-export function buildAttackEffectsMessage(attacker, defender, item, attackAttribute, defenseAttribute, inputBoons) {
+export function buildAttackEffectsMessage(attacker, defender, item, attackAttribute, defenseAttribute, inputBoons, plus20) {
   const attackerEffects = attacker.getEmbeddedCollection('ActiveEffect').filter(effect => !effect.disabled)
   let m = _remapEffects(attackerEffects)
 
@@ -84,7 +84,7 @@ export function buildAttackEffectsMessage(attacker, defender, item, attackAttrib
       if (item.system.wear && +item.system.requirement?.minvalue > attacker.getAttribute(item.system.requirement?.attribute)?.value) itemBoons-- // If the requirements are not met, decrease the boons on the weapon
       break
     case 'talent':
-      if (!attackAttribute) return
+      if (!attackAttribute) break
       itemBoons = item.system.action.boonsbanes
       break
     default:
@@ -98,11 +98,14 @@ export function buildAttackEffectsMessage(attacker, defender, item, attackAttrib
     (defenderBoons ? _toMsg(defenderString, -defenderBoons) : '')
   boonsMsg = boonsMsg ? `&nbsp;&nbsp;${game.i18n.localize('DL.TalentAttackBoonsBanes')}<br>` + boonsMsg : ''
 
+  const extraDamageMsg = item.system.action?.damage ? changeToMsg(m, 'system.bonuses.attack.damage', 'DL.TalentExtraDamage') : ''
+  // We may want to show the extra damage 
+  const extraDamage20PlusMsg = ((!defender && attackAttribute) || plus20) ? changeToMsg(m, 'system.bonuses.attack.plus20Damage', 'DL.TalentExtraDamage20plus') : ''
   return (
     boonsMsg +
     inputBoonsMsg + 
-    changeToMsg(m, 'system.bonuses.attack.damage', 'DL.TalentExtraDamage') +
-    changeToMsg(m, 'system.bonuses.attack.plus20Damage', 'DL.TalentExtraDamage20plus')
+    extraDamageMsg +
+    extraDamage20PlusMsg
   )
   // + changeToMsg(m, 'system.bonuses.attack.extraEffect', 'DL.TalentExtraEffect')
 }

--- a/src/module/chat/roll-messages.js
+++ b/src/module/chat/roll-messages.js
@@ -58,10 +58,11 @@ export function postAttackToChat(attacker, defender, item, attackRoll, attackAtt
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  data['damageFormula'] = itemData.action?.damage + attacker.system.bonuses.attack.damage
+  data['damageFormula'] = itemData?.action?.damage
+  data['extraDamageFormula'] = attacker.system.bonuses.attack.damage
   data['damageType'] = itemData.action.damagetype
   data['damageTypes'] = itemData.action.damagetypes
-  data['damageExtra20PlusFormula'] = [itemData.action.plus20damage, attacker.system.bonuses.attack.plus20Damage].filter(Boolean)
+  data['damageExtra20PlusFormula'] = itemData.action?.plus20damage + attacker.system.bonuses?.attack?.plus20Damage
   data['description'] = itemData.description
   data['defense'] = itemData.action?.defense
   data['defenseboonsbanes'] = parseInt(itemData.action?.defenseboonsbanes)
@@ -75,7 +76,7 @@ export function postAttackToChat(attacker, defender, item, attackRoll, attackAtt
   data['isPlus20Roll'] = plus20
   data['hasTarget'] = targetNumber !== undefined
   data['effects'] = attacker.system.bonuses.attack.extraEffect
-  data['attackEffects'] = buildAttackEffectsMessage(attacker, defender, item, attackAttribute, defenseAttribute, inputBoons)
+  data['attackEffects'] = buildAttackEffectsMessage(attacker, defender, item, attackAttribute, defenseAttribute, inputBoons, plus20)
   data['armorEffects'] = '' // TODO
   data['afflictionEffects'] = '' //TODO
   data['ifBlindedRoll'] = rollMode === 'blindroll'
@@ -216,10 +217,11 @@ export function postTalentToChat(actor, talent, attackRoll, target, inputBoons) 
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  data['damageFormula'] = talentData.action?.damage ? talentData?.action?.damage + actor.system.bonuses.attack.damage || '' : talentData?.action?.damage
+  data['damageFormula'] = talentData?.action?.damage
+  data['extraDamageFormula'] = actor.system.bonuses.attack.damage
   data['damageType'] = talentData.action?.damageactive && talentData?.action?.damage ? talentData?.action?.damagetype : talentData?.action?.damagetype
   data['damageTypes'] = talentData.action?.damagetypes
-  data['damageExtra20PlusFormula'] = [talentData.action?.plus20damage, actor.system.bonuses?.attack?.plus20Damage].filter(Boolean)
+  data['damageExtra20PlusFormula'] = talentData.action?.plus20damage + actor.system.bonuses?.attack?.plus20Damage
   data['description'] = talentData.description
   data['defense'] = talentData.action?.defense
   data['defenseboonsbanes'] = parseInt(talentData.action?.defenseboonsbanes)
@@ -236,7 +238,7 @@ export function postTalentToChat(actor, talent, attackRoll, target, inputBoons) 
   data['hasTarget'] = targetNumber !== undefined
   data['pureDamage'] = talentData?.damage
   data['pureDamageType'] = talentData?.damagetype
-  data['attackEffects'] = buildAttackEffectsMessage(actor, target, talent, attackAttribute, defenseAttribute, inputBoons)
+  data['attackEffects'] = buildAttackEffectsMessage(actor, target, talent, attackAttribute, defenseAttribute, inputBoons, plus20)
   data['effects'] = buildTalentEffectsMessage(actor, talent)
   data['ifBlindedRoll'] = rollMode === 'blindroll'
   data['hasAreaTarget'] = talentData?.activatedEffect?.target?.type in CONFIG.DL.actionAreaShape
@@ -329,10 +331,11 @@ export async function postSpellToChat(actor, spell, attackRoll, target, inputBoo
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  data['damageFormula'] = spellData.action?.damage + actor.system.bonuses.attack.damage
+  data['damageFormula'] = spellData?.action?.damage
+  data['extraDamageFormula'] = actor.system.bonuses.attack.damage
   data['damageType'] = spellData.action?.damagetype
   data['damageTypes'] = spellData.action?.damagetypes
-  data['damageExtra20PlusFormula'] = [spellData.action?.plus20damage, actor.system.bonuses?.attack?.plus20Damage].filter(Boolean)
+  data['damageExtra20PlusFormula'] = spellData.action?.plus20damage + actor.system.bonuses?.attack?.plus20Damage
   data['description'] = spellData.description
   data['defense'] = spellData.action?.defense
   data['defenseboonsbanes'] = parseInt(spellData.action?.defenseboonsbanes)
@@ -361,7 +364,7 @@ export async function postSpellToChat(actor, spell, attackRoll, target, inputBoo
   data['isPlus20Roll'] = plus20
   data['effectdice'] = effectdice
   data['effects'] = '' // FIXME: what to put in here??
-  data['attackEffects'] = buildAttackEffectsMessage(actor, target, spell, attackAttribute, defenseAttribute, inputBoons)
+  data['attackEffects'] = buildAttackEffectsMessage(actor, target, spell, attackAttribute, defenseAttribute, inputBoons, plus20)
   data['ifBlindedRoll'] = rollMode === 'blindroll'
   data['hasAreaTarget'] = spellData?.activatedEffect?.target?.type in CONFIG.DL.actionAreaShape
   data['itemEffects'] = spell.effects
@@ -500,10 +503,11 @@ export const postItemToChat = (actor, item, attackRoll, target, inputBoons) => {
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  data['damageFormula'] = itemData.action?.damage + actor.system.bonuses.attack.damage
+  data['damageFormula'] = itemData?.action?.damage
+  data['extraDamageFormula'] = actor.system.bonuses.attack.damage
   data['damageType'] = itemData.action?.damagetype
   data['damageTypes'] = itemData.action?.damagetypes
-  data['damageExtra20PlusFormula'] = [itemData.action?.plus20damage, actor.system.bonuses?.attack?.plus20Damage].filter(Boolean)
+  data['damageExtra20PlusFormula'] = itemData.action?.plus20damage + actor.system.bonuses?.attack?.plus20Damage
   data['description'] = itemData.description
   data['defense'] = itemData.action?.defense
   data['defenseboonsbanes'] = parseInt(itemData.action?.defenseboonsbanes)
@@ -517,7 +521,7 @@ export const postItemToChat = (actor, item, attackRoll, target, inputBoons) => {
   data['isPlus20Roll'] = plus20
   data['hasTarget'] = targetNumber !== undefined
   data['effects'] = actor.system.bonuses.attack.extraEffect
-  data['attackEffects'] = buildAttackEffectsMessage(actor, target, item, attackAttribute, defenseAttribute, inputBoons)
+  data['attackEffects'] = buildAttackEffectsMessage(actor, target, item, attackAttribute, defenseAttribute, inputBoons, plus20)
   data['armorEffects'] = '' // TODO
   data['afflictionEffects'] = '' //TODO
   data['ifBlindedRoll'] = rollMode === 'blindroll'

--- a/src/module/chat/roll-messages.js
+++ b/src/module/chat/roll-messages.js
@@ -61,7 +61,7 @@ export function postAttackToChat(attacker, defender, item, attackRoll, attackAtt
   data['damageFormula'] = itemData.action?.damage + attacker.system.bonuses.attack.damage
   data['damageType'] = itemData.action.damagetype
   data['damageTypes'] = itemData.action.damagetypes
-  data['damageExtra20PlusFormula'] = itemData.action.plus20damage ? item.system.action.plus20damage : attacker.system.bonuses.attack.plus20Damage
+  data['damageExtra20PlusFormula'] = [itemData.action.plus20damage, attacker.system.bonuses.attack.plus20Damage].filter(Boolean)
   data['description'] = itemData.description
   data['defense'] = itemData.action?.defense
   data['defenseboonsbanes'] = parseInt(itemData.action?.defenseboonsbanes)
@@ -219,7 +219,7 @@ export function postTalentToChat(actor, talent, attackRoll, target, inputBoons) 
   data['damageFormula'] = talentData.action?.damage ? talentData?.action?.damage + actor.system.bonuses.attack.damage || '' : talentData?.action?.damage
   data['damageType'] = talentData.action?.damageactive && talentData?.action?.damage ? talentData?.action?.damagetype : talentData?.action?.damagetype
   data['damageTypes'] = talentData.action?.damagetypes
-  data['damageExtra20PlusFormula'] = talentData.action?.plus20damage ? talentData?.action?.plus20damage : talentData?.action?.plus20damage
+  data['damageExtra20PlusFormula'] = [talentData.action?.plus20damage, actor.system.bonuses?.attack?.plus20Damage].filter(Boolean)
   data['description'] = talentData.description
   data['defense'] = talentData.action?.defense
   data['defenseboonsbanes'] = parseInt(talentData.action?.defenseboonsbanes)
@@ -332,7 +332,7 @@ export async function postSpellToChat(actor, spell, attackRoll, target, inputBoo
   data['damageFormula'] = spellData.action?.damage + actor.system.bonuses.attack.damage
   data['damageType'] = spellData.action?.damagetype
   data['damageTypes'] = spellData.action?.damagetypes
-  data['damageExtra20PlusFormula'] = spellData.action?.plus20damage
+  data['damageExtra20PlusFormula'] = [spellData.action?.plus20damage, actor.system.bonuses?.attack?.plus20Damage].filter(Boolean)
   data['description'] = spellData.description
   data['defense'] = spellData.action?.defense
   data['defenseboonsbanes'] = parseInt(spellData.action?.defenseboonsbanes)
@@ -503,7 +503,7 @@ export const postItemToChat = (actor, item, attackRoll, target, inputBoons) => {
   data['damageFormula'] = itemData.action?.damage + actor.system.bonuses.attack.damage
   data['damageType'] = itemData.action?.damagetype
   data['damageTypes'] = itemData.action?.damagetypes
-  data['damageExtra20PlusFormula'] = itemData.action?.plus20damage ? item.system.action?.plus20damage : actor.system.bonuses.attack.plus20Damage
+  data['damageExtra20PlusFormula'] = [itemData.action?.plus20damage, actor.system.bonuses?.attack?.plus20Damage].filter(Boolean)
   data['description'] = itemData.description
   data['defense'] = itemData.action?.defense
   data['defenseboonsbanes'] = parseInt(itemData.action?.defenseboonsbanes)

--- a/src/module/combat/combat-tracker.js
+++ b/src/module/combat/combat-tracker.js
@@ -35,7 +35,7 @@ export class DLCombatTracker extends CombatTracker {
       // Add Tooltip on Status Effects
       // Group actor effects by image
       const imgEffectMap = new Map()
-      combatant.actor.effects
+      combatant.actor?.effects
         .filter(e => e.isTemporary && !e.disabled)
         .forEach(e => {
           if (imgEffectMap.has(e.icon)) imgEffectMap.get(e.icon).push(e)

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -54,7 +54,7 @@ DL.actionAreaShape = {
   hemisphere: 'circle',
   line: 'ray',
   sphere: 'circle',
-  square: 'react',
+  square: 'rect',
 }
 
 DL.actionDuration = {

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -112,4 +112,5 @@ DL.defaultItemIcons = {
     master: 'systems/demonlord/assets/icons/badges/helm-01.webp',
   },
   creaturerole: 'icons/equipment/back/cape-layered-blue-accent.webp',
+  relic: 'icons/commodities/treasure/sceptre-jeweled-gold.webp'
 }

--- a/src/module/demonlord.js
+++ b/src/module/demonlord.js
@@ -60,6 +60,9 @@ Hooks.once('init', async function () {
   CONFIG.Combat.documentClass = DLCombat
   CONFIG.time.roundTime = 10
   // CONFIG.debug.hooks = true
+  
+  // Move to new ActiveEffect transferral
+  CONFIG.ActiveEffect.legacyTransferral = false;
 
   registerSettings()
 

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -8,7 +8,7 @@ export class DemonlordItem extends Item {
     if (this.type === 'spell' && this.parent) {
       const power = +this.parent.system?.characteristics.power || 0
       const rank = updateData?.data?.rank ?? +this.system.rank
-      updateData['data.castings.max'] = CONFIG.DL.spelluses[power]?.[rank] ?? updateData?.data?.castings?.max ?? 0
+      updateData['system.castings.max'] = CONFIG.DL.spelluses[power]?.[rank] ?? updateData?.data?.castings?.max ?? 0
     }
     return await super.update(updateData)
   }

--- a/src/module/item/sheets/ancestry-sheet.js
+++ b/src/module/item/sheets/ancestry-sheet.js
@@ -61,7 +61,7 @@ export default class DLAncestrySheet extends DLBaseItemSheet {
     // Edit ancestry talents
     html
       .find('.edit-ancestrytalents')
-      .click(async _ => await this.item.update({'data.editTalents': !this.item.system.editTalents}).then(() => this.render()))
+      .click(async _ => await this.item.update({'system.editTalents': !this.item.system.editTalents}).then(() => this.render()))
 
     // Delete ancestry item
     html.find('.delete-ancestryitem').click(async ev => {

--- a/src/module/item/sheets/base-item-sheet.js
+++ b/src/module/item/sheets/base-item-sheet.js
@@ -69,11 +69,7 @@ export default class DLBaseItemSheet extends ItemSheet {
     data.system.enrichedDescription = await TextEditor.enrichHTML(this.document.system.description, {async: true});
     data.system.enrichedDescriptionUnrolled = await enrichHTMLUnrolled(this.document.system.description)
 
-    const effControls = data.document.isEmbedded ? -1 : 3
-    data.effects =
-      this.document.effects.size > 0 || !data.document.isEmbedded
-        ? prepareActiveEffectCategories(this.document.effects, !data.document.isEmbedded, effControls)
-        : null
+    data.effects = prepareActiveEffectCategories(this.document.effects, true, true)
 
     if (data.item.type === 'weapon' || data.item.type === 'spell' || data.item.type === 'talent') this._prepareDamageTypes(data)
 

--- a/src/module/item/sheets/base-item-sheet.js
+++ b/src/module/item/sheets/base-item-sheet.js
@@ -117,7 +117,7 @@ export default class DLBaseItemSheet extends ItemSheet {
     }
 
     // If a Talent has no uses it's always active
-    if (item.type === 'talent') updateData['data.addtonextroll'] = !updateData.data?.uses?.max
+    if (item.type === 'talent') updateData['system.addtonextroll'] = !updateData.data?.uses?.max
 
     return await this.object.update(updateData)
   }

--- a/src/module/item/sheets/path-sheet.js
+++ b/src/module/item/sheets/path-sheet.js
@@ -58,7 +58,7 @@ export default class DLPathSheet extends DLBaseItemSheet {
     html.find('.add-level').click(async ev => {
       ev.preventDefault()
       await this.item.update({
-        'data.levels': [...(this.item.system.levels || []), new PathLevel()],
+        'system.levels': [...(this.item.system.levels || []), new PathLevel()],
       })
     })
 
@@ -101,7 +101,7 @@ export default class DLPathSheet extends DLBaseItemSheet {
           callback: async _ => {
             const levels = this.item.system.levels
             levels.splice(itemIndex, 1)
-            await this.item.update({'data.levels': levels})
+            await this.item.update({'system.levels': levels})
           },
         },
         no: {
@@ -187,7 +187,7 @@ export default class DLPathSheet extends DLBaseItemSheet {
         const hasADefaultImage = Object.values(CONFIG.DL.defaultItemIcons.path).includes(formData.img)
         if (game.settings.get('demonlord', 'replaceIcons') && hasADefaultImage) {
           formData.img =
-            CONFIG.DL.defaultItemIcons.path[formData['data.type']] || CONFIG.DL.defaultItemIcons.path.novice
+            CONFIG.DL.defaultItemIcons.path[formData['system.type']] || CONFIG.DL.defaultItemIcons.path.novice
         }
       } else {
         updateData.levels = this._getViewLevelsUpdateData(completeFormData)

--- a/src/module/item/sheets/role-sheet.js
+++ b/src/module/item/sheets/role-sheet.js
@@ -58,7 +58,7 @@ export default class DLRoleSheet extends DLBaseItemSheet {
     // Edit role talents
     html
       .find('.edit-roletalents')
-      .click(async _ => await this.item.update({'data.editTalents': !this.item.system.editTalents}).then(() => this.render()))
+      .click(async _ => await this.item.update({'system.editTalents': !this.item.system.editTalents}).then(() => this.render()))
 
     // Delete role item
     html.find('.delete-roleitem').click(async ev => {

--- a/src/module/macros/gm-macros.js
+++ b/src/module/macros/gm-macros.js
@@ -233,10 +233,10 @@ export function wealthManagerMacro() {
 
     await actors[0].update(
       {
-        'data.wealth.gc': currentGC + parseInt(gc),
-        'data.wealth.ss': currentSS + parseInt(ss),
-        'data.wealth.cp': currentCP + parseInt(cp),
-        'data.wealth.bits': currentBits + parseInt(bits)
+        'system.wealth.gc': currentGC + parseInt(gc),
+        'system.wealth.ss': currentSS + parseInt(ss),
+        'system.wealth.cp': currentCP + parseInt(cp),
+        'system.wealth.bits': currentBits + parseInt(bits)
       });
     expMessage(actors[0].name, gc, ss, cp, bits);
   }
@@ -254,10 +254,10 @@ export function wealthManagerMacro() {
 
       await actor.update(
         {
-          'data.wealth.gc': currentGC + parseInt(gc),
-          'data.wealth.ss': currentSS + parseInt(ss),
-          'data.wealth.cp': currentCP + parseInt(cp),
-          'data.wealth.bits': currentBits + parseInt(bits)
+          'system.wealth.gc': currentGC + parseInt(gc),
+          'system.wealth.ss': currentSS + parseInt(ss),
+          'system.wealth.cp': currentCP + parseInt(cp),
+          'system.wealth.bits': currentBits + parseInt(bits)
         });
 
       expMessage(actor.name, gc, ss, cp, bits);

--- a/src/module/macros/item-macros.js
+++ b/src/module/macros/item-macros.js
@@ -192,7 +192,7 @@ export async function healingPotionMacro() {
     if (newdamage < 0) newdamage = 0
 
     await Actor.updateDocuments({
-      'data.characteristics.health.value': newdamage,
+      'system.characteristics.health.value': newdamage,
     })
 
     var templateData = {

--- a/src/templates/actor/creature-header.hbs
+++ b/src/templates/actor/creature-header.hbs
@@ -24,7 +24,9 @@
       <div class="col-2 attribute" style="margin-top: 8px">
         <label class="name" data-key="{{n}}">{{attr.label}}</label>
         <input type="{{ifThen attr.immune "text" "Number"}}" name="system.attributes.{{n}}.value" value="{{ifThen attr.immune "-" attr.value}}" {{disabled attr.immune}}/>
-        <label class="modifier">{{plusify attr.modifier}}</label>
+        {{#unless attr.immune}}
+          <label class="modifier">{{plusify attr.modifier}}</label>
+        {{/unless}}
       </div>
     {{/inline}}
 

--- a/src/templates/actor/header.hbs
+++ b/src/templates/actor/header.hbs
@@ -15,7 +15,9 @@
       <div class="col-2 attribute" style="margin-top: 8px">
         <label class="name" data-key="{{n}}">{{attr.label}}</label>
         <input type="{{ifThen attr.immune "text" "Number"}}" name="system.attributes.{{n}}.value" value="{{ifThen attr.immune "-" attr.value}}" readonly/>
-        <label class="modifier">{{plusify attr.modifier}}</label>
+        {{#unless attr.immune}}
+          <label class="modifier">{{plusify attr.modifier}}</label>
+        {{/unless}}
       </div>
     {{/inline}}
 

--- a/src/templates/actor/vehicle-header.hbs
+++ b/src/templates/actor/vehicle-header.hbs
@@ -25,7 +25,9 @@
         {{else}}
           <input type="Number" name="system.attributes.{{n}}.value" value="{{attr.value}}"/>
         {{/if}}
-        <label class="modifier">{{plusify attr.modifier}}</label>
+        {{#unless attr.immune}}
+          <label class="modifier">{{plusify attr.modifier}}</label>
+        {{/unless}}
       </div>
     {{/inline}}
 

--- a/src/templates/chat/combat.hbs
+++ b/src/templates/chat/combat.hbs
@@ -2,7 +2,7 @@
   <div class="demonlord" {{#if actor.id}}data-actor-id="{{actor.id}}" {{/if}} {{#if item.id}}data-item-id="{{item.id}}" {{/if}} {{#if tokenId}}data-token-id="{{tokenId}}" {{/if}}>
     <div class="showlessinfo">{{data.actorInfo}}</div>
     <header class="card-header">
-      <div class="token-img"><img class="profile-img" src="{{item.data.img}}" data-edit="img" title="{{item.data.name}}" height="40" width="40"/></div>
+      <div class="token-img"><img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" height="40" width="40"/></div>
       <div class="attackbox">
         <div class="boxline">
           <div class="header">{{localize "DL.AttackRollText"}}</div>

--- a/src/templates/chat/combat.hbs
+++ b/src/templates/chat/combat.hbs
@@ -2,11 +2,11 @@
   <div class="demonlord" {{#if actor.id}}data-actor-id="{{actor.id}}" {{/if}} {{#if item.id}}data-item-id="{{item.id}}" {{/if}} {{#if tokenId}}data-token-id="{{tokenId}}" {{/if}}>
     <div class="showlessinfo">{{data.actorInfo}}</div>
     <header class="card-header">
-      <div class="token-img"><img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" height="40" width="40"/></div>
+      <div class="token-img"><img class="profile-img" src="{{item.data.img}}" data-edit="img" title="{{item.data.name}}" height="40" width="40"/></div>
       <div class="attackbox">
         <div class="boxline">
           <div class="header">{{localize "DL.AttackRollText"}}</div>
-          <div class="headertext">{{item.name}}</div>
+          <div class="headertext">{{item.data.name}}</div>
         </div>
         <div class="boxline">
           <div class="header">{{localize "DL.TargetRollText"}}</div>

--- a/src/templates/chat/partial/chat-attack.hbs
+++ b/src/templates/chat/partial/chat-attack.hbs
@@ -86,53 +86,53 @@
       </div>
     {{/if}}
   </div>
+{{/if}}
 
-  {{#if data.attackEffects}}
-    {{#if data.isCreature}}
-      <div class="gmonly">
-        <div class="description">
-          <div class="header">{{localize "DL.AttackRollBonuses"}}:</div>
-          <div class="body">{{{data.attackEffects}}}
-            <hr>
-          </div>
-        </div>
-      </div>
-    {{else}}
+{{#if data.attackEffects}}
+  {{#if data.isCreature}}
+    <div class="gmonly">
       <div class="description">
         <div class="header">{{localize "DL.AttackRollBonuses"}}:</div>
         <div class="body">{{{data.attackEffects}}}
           <hr>
         </div>
       </div>
-    {{/if}}
-  {{/if}}
-
-  {{#if data.effects}}
-    {{#if data.isCreature}}
-      <div class="gmonly">
-        <div class="description">
-          <div class="header">{{localize "DL.TalentRollEffects"}}</div>
-          <div class="body">{{{data.effects}}}</div>
-        </div>
+    </div>
+  {{else}}
+    <div class="description">
+      <div class="header">{{localize "DL.AttackRollBonuses"}}:</div>
+      <div class="body">{{{data.attackEffects}}}
+        <hr>
       </div>
-    {{else}}
+    </div>
+  {{/if}}
+{{/if}}
+
+{{#if data.effects}}
+  {{#if data.isCreature}}
+    <div class="gmonly">
       <div class="description">
         <div class="header">{{localize "DL.TalentRollEffects"}}</div>
         <div class="body">{{{data.effects}}}</div>
       </div>
-    {{/if}}
+    </div>
+  {{else}}
+    <div class="description">
+      <div class="header">{{localize "DL.TalentRollEffects"}}</div>
+      <div class="body">{{{data.effects}}}</div>
+    </div>
   {{/if}}
+{{/if}}
 
-  {{#if data.effectdice}}
-    <div class="roll20">
-      <div class="header">{{localize "DL.SpellEffectDice"}}</div>
-      <div class="body">{{localize "DL.SpellEffectDiceResult"}} {{data.effectdice}}</div>
-    </div>
-  {{/if}}
-  {{#if data.plus20Text}}
-    <div class="roll20">
-      <div class="header">{{localize "DL.SpellRollPlus20"}}</div>
-      <div class="body">{{data.plus20Text}}</div>
-    </div>
-  {{/if}}
+{{#if data.effectdice}}
+  <div class="roll20">
+    <div class="header">{{localize "DL.SpellEffectDice"}}</div>
+    <div class="body">{{localize "DL.SpellEffectDiceResult"}} {{data.effectdice}}</div>
+  </div>
+{{/if}}
+{{#if data.plus20Text}}
+  <div class="roll20">
+    <div class="header">{{localize "DL.SpellRollPlus20"}}</div>
+    <div class="body">{{data.plus20Text}}</div>
+  </div>
 {{/if}}

--- a/src/templates/chat/partial/chat-damage.hbs
+++ b/src/templates/chat/partial/chat-damage.hbs
@@ -1,7 +1,9 @@
 {{!--
   Variables:
     - data
+      - attack
       - damageFormula
+      - extraDamageFormula
       - damageType
       - damageTypes
       - pureDamage
@@ -11,10 +13,10 @@
 
 {{#if data.damageFormula}}
   <div class="combatactions roll-damage">
-    <div class="header" data-item-id="{{data.id}}" data-damage="{{data.damageFormula}}"
+    <div class="header" data-item-id="{{data.id}}" data-damage="{{data.damageFormula}}{{data.extraDamageFormula}}"
       data-damagetype="{{data.damageType}}">
       <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15" />
-      <div>{{data.damageType}} {{localize "DL.WeaponDamage"}} ({{data.damageFormula}})</div>
+      <div>{{data.damageType}} {{localize "DL.WeaponDamage"}} ({{data.damageFormula}}{{data.extraDamageFormula}})</div>
     </div>
   </div>
 {{/if}}
@@ -36,26 +38,28 @@
     </div>
   </div>
 {{/if}}
-{{#if data.damageExtra20PlusFormula}}
-  {{#if data.hasTarget}}
-    {{#if data.isPlus20Roll}}
-      {{#each data.damageExtra20PlusFormula as |damageExtra20PlusFormula id|}}
+{{#if data.attack}}
+  {{#if data.damageExtra20PlusFormula}}
+    {{#if data.hasTarget}}
+      {{#if data.isPlus20Roll}}
+        {{#if data.damageExtra20PlusFormula}}
+          <div class="combatactions roll-damage">
+            <div class="header" data-item-id="{{data.id}}" data-damage="{{data.damageExtra20PlusFormula}}">
+              <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15" />
+              <div>{{localize "DL.TalentExtraDamage20plus"}} ({{data.damageExtra20PlusFormula}})</div>
+            </div>
+          </div>
+        {{/if}}
+      {{/if}}
+    {{else}}
+      {{#if data.damageExtra20PlusFormula }}
         <div class="combatactions roll-damage">
-          <div class="header" data-item-id="{{data.id}}" data-damage="{{damageExtra20PlusFormula}}">
+          <div class="header" data-item-id="{{id}}" data-damage="{{data.damageExtra20PlusFormula}}">
             <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15" />
-            <div>{{localize "DL.TalentExtraDamage20plus"}} ({{damageExtra20PlusFormula}})</div>
+            <div>{{localize "DL.TalentExtraDamage20plus"}} ({{data.damageExtra20PlusFormula}})</div>
           </div>
         </div>
-      {{/each}}
+      {{/if}}
     {{/if}}
-  {{else}}
-    {{#each data.damageExtra20PlusFormula as |damageExtra20PlusFormula id|}}
-      <div class="combatactions roll-damage">
-        <div class="header" data-item-id="{{id}}" data-damage="{{damageExtra20PlusFormula}}">
-          <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15" />
-          <div>{{localize "DL.TalentExtraDamage20plus"}} ({{damageExtra20PlusFormula}})</div>
-        </div>
-      </div>
-    {{/each}}
   {{/if}}
 {{/if}}

--- a/src/templates/chat/partial/chat-damage.hbs
+++ b/src/templates/chat/partial/chat-damage.hbs
@@ -39,19 +39,23 @@
 {{#if data.damageExtra20PlusFormula}}
   {{#if data.hasTarget}}
     {{#if data.isPlus20Roll}}
-      <div class="combatactions roll-damage">
-        <div class="header" data-item-id="{{data.id}}" data-damage="{{data.damageExtra20PlusFormula}}">
-          <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15" />
-          <div>{{localize "DL.TalentExtraDamage20plus"}} ({{data.damageExtra20PlusFormula}})</div>
+      {{#each data.damageExtra20PlusFormula as |damageExtra20PlusFormula id|}}
+        <div class="combatactions roll-damage">
+          <div class="header" data-item-id="{{data.id}}" data-damage="{{damageExtra20PlusFormula}}">
+            <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15" />
+            <div>{{localize "DL.TalentExtraDamage20plus"}} ({{damageExtra20PlusFormula}})</div>
+          </div>
         </div>
-      </div>
+      {{/each}}
     {{/if}}
   {{else}}
-    <div class="combatactions roll-damage">
-      <div class="header" data-item-id="{{data.id}}" data-damage="{{data.damageExtra20PlusFormula}}">
-        <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15" />
-        <div>{{localize "DL.TalentExtraDamage20plus"}} ({{data.damageExtra20PlusFormula}})</div>
+    {{#each data.damageExtra20PlusFormula as |damageExtra20PlusFormula id|}}
+      <div class="combatactions roll-damage">
+        <div class="header" data-item-id="{{id}}" data-damage="{{damageExtra20PlusFormula}}">
+          <img src="systems/demonlord/assets/ui/items/damage.webp" width="15" height="15" />
+          <div>{{localize "DL.TalentExtraDamage20plus"}} ({{damageExtra20PlusFormula}})</div>
+        </div>
       </div>
-    </div>
+    {{/each}}
   {{/if}}
 {{/if}}

--- a/src/templates/item/partial/item-effects.hbs
+++ b/src/templates/item/partial/item-effects.hbs
@@ -1,17 +1,6 @@
 {{#if effects}}
   <div class="tab" data-group="primary" data-tab="effects">
-    {{#if document.isEmbedded}}
-      <!--    TODO-->
-      <p class="warning" style="margin-bottom: 12px; background: #8d3b3c; border-radius: 8px; padding: 8px;
-      font-size: 14px; border:1px solid black">
-        <b>WARNING:</b><br> As of Foundry 0.8.5 the creation of Active Effects inside Items owned by a Character is
-        unsupported.
-        To edit effects present in the item, please edit the item from the Sidebar.
-      </p>
-
-    {{/if}}
-
-    <ol class="items-list effects-list" style="margin-top: 0; padding: 0 8px;">
+    <ol class="items-list effects-list" style="margin: 0; padding: 0 8px;">
       {{#each effects as |section sid|}}
         <li class="items-header flexrow" data-effect-type="{{section.type}}">
           <div class="item-name effect-name flexrow">{{localize section.name}}</div>
@@ -52,7 +41,7 @@
                 </a>
               {{/if}} {{#if (eq section.showControls 3)}}
                 <a class="effect-control" data-action="toggle" title="{{localize 'DL.EffectToggle'}}">
-                  <i class="fas {{#if effect.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
+                  <i class="fas {{ifThen effect.disabled "fa-check" "fa-times"}}"></i>
                 </a>
                 <a class="effect-control" data-action="edit" title="{{localize 'DL.EffectEdit'}}">
                   <i class="fas fa-edit"></i>


### PR DESCRIPTION
## 3.6.0

### New Features:

- Normalise appearance of attack messages and damage buttons across item types
- Allow 20 plus damage from multiple sources (e.g. talent and active effect)
- Support active effects that affect size
- Hide modifier label for immune attributes
- Move to modern effect transferral mode

### Fixes:
- Fix broken square measured templates
- Add default image for relics
- Remove references to deprecated `data`
- Don't break when combat has null actors