### PR TITLE
Displaying then number of items in container-items.

### DIFF
--- a/src/templates/tabs/item.hbs
+++ b/src/templates/tabs/item.hbs
@@ -69,7 +69,11 @@
       <div class="col-7">
         <img class='dl-clickable-nored item-edit' src="{{item.img}}" title="{{item.name}}" width="32"
              height="32"/>
-        <label class="dl-clickable-nored item-roll">{{item.name}}</label>
+        {{#if item.system.contents.length}}
+          <label class="dl-clickable-nored item-roll">{{item.name}} ({{item.system.contents.length}})</label>
+        {{else}}
+          <label class="dl-clickable-nored item-roll">{{item.name}}</label>
+        {{/if}}
         <div class="dl-clickable dlToggleInfoBtn">
           <i class="fas fa-angle-right"></i> {{localize "DL.ItemShowInfo"}}
         </div>


### PR DESCRIPTION
If an item is a container, the number of items in it is displayed in round brackets after its name.

![image](https://github.com/Xacus/demonlord/assets/92884040/abbeb500-13dc-4832-8f1b-05f631ce5097)
