### PR TITLE
Creature side-tab CSS fix. Creature role display glitch.

### DIFF
--- a/src/styles/components/actor-sheets/_aside-creature.scss
+++ b/src/styles/components/actor-sheets/_aside-creature.scss
@@ -130,17 +130,18 @@ form {
     transition: left 200ms ease-in-out;
     position: relative;
     background-color: var(--demonlord-red);
-    width: 100px;
+    width: 150px;
     height: 32px;
     border-radius: 0 5px 5px 0;
     line-height: 32px;
     text-align: center;
-    left: -80px;
+    left: -130px;
     pointer-events: initial;
   }
 
   .dl-side-tab:hover {
     left: -20px;
+    margin-left: 20px;
   }
 }
 


### PR DESCRIPTION
Before:
![image](https://github.com/Xacus/demonlord/assets/92884040/2ced953f-1451-42a7-81b9-2053a7c76d52)

After:
![image](https://github.com/Xacus/demonlord/assets/92884040/f60a2683-7c17-413a-8294-44386146d810)
