### PR TITLE
Banes on attack rolls against horrifying creatures

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -568,6 +568,8 @@
   "DL.Setting.DiagonalRuleManh": "Manhattan / Taxicab",
   "DL.SettingGMEffectsControls": "GM Effects Controls",
   "DL.SettingGMEffectsControlsHint": "Always show the active effects controls in the character sheets (toggle, edit and delete) to the Game Master, regardless of the effect type.",
+  "DL.SettingHorrifyingBane": "Bane against horrifying creatures",
+  "DL.SettingHorrifyingBaneHint": "Apply a bane on all attack rolls targeting a horrifying creature, unless the attacker has the frightening or horrifying trait.",
   "DL.SettingInitMessage": "Initiative Messages",
   "DL.SettingInitMessageHint": "Show if player chooses Fast or Slow turn in Chat Log.",
   "DL.SettingInitRandomize": "Initiative Randomize",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -550,6 +550,8 @@
   "DL.SettingConfirmAncestryPathRemovalHint": "Afficher une boîte de dialogue de confirmation lors de la suppression d'une ascendance ou d'une voie d'un personnage de niveau 1 ou supérieur.",
   "DL.SettingGMEffectsControls": "Commandes d'effets du MJ",
   "DL.SettingGMEffectsControlsHint": "Toujours montrer au MJ les commandes d'effets actives dans les feuilles de personnage (basculer, modifier et supprimer), quel que soit le type d'effet.",
+  "DL.SettingHorrifyingBane": "Désavantage contre les créatures terrifiantes",
+  "DL.SettingHorrifyingBaneHint": "Appliquer un désavantage à tous les jets d'attaque qui ciblent une créature terrifiante, sauf si l'attaquant a le trait effrayant ou terrifiant.",
   "DL.SettingInitMessage": "Messages d'initiative",
   "DL.SettingInitMessageHint": "Indiquer si le joueur choisit un tour rapide ou lent dans le journal de chat.",
   "DL.SettingInitRandomize": "Initiative aléatoire",

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -375,12 +375,15 @@ export class DemonlordActor extends Actor {
       (attacker.system.bonuses.attack.boons.all || 0) +
       (attacker.system.bonuses.attack.boons.weapon || 0)
 
+    const horrifyingBane = game.settings.get('demonlord', 'horrifyingBane')
+
     // The defender banes apply only if the defender is one target
     if (defendersTokens.length === 1)
       boons -=
         (defender?.system.bonuses.defense.boons[defenseAttribute] || 0) +
         (defender?.system.bonuses.defense.boons.all || 0) +
-        (defender?.system.bonuses.defense.boons.weapon || 0)
+        (defender?.system.bonuses.defense.boons.weapon || 0) +
+        (horrifyingBane && !attacker.system.horrifying && !attacker.system.frightening && defender?.system.horrifying && 1 || 0)
 
     // Check if requirements met
     if (item.system.wear && parseInt(item.system.requirement?.minvalue) > attacker.getAttribute(item.system.requirement?.attribute)?.value)
@@ -525,7 +528,14 @@ export class DemonlordActor extends Actor {
         (this.system.bonuses.attack.boons[attackAttribute] || 0) +
         (this.system.bonuses.attack.boons.all || 0) +
         parseInt(talentData.action?.boonsbanes || 0)
-      if (targets.length === 1) boons -= ((target?.actor?.system.bonuses.defense.boons[defenseAttribute] || 0) + (target?.actor?.system.bonuses.defense.boons.all || 0))
+
+      const horrifyingBane = game.settings.get('demonlord', 'horrifyingBane')
+
+      if (targets.length === 1)
+        boons -= (
+          (target?.actor?.system.bonuses.defense.boons[defenseAttribute] || 0) +
+          (target?.actor?.system.bonuses.defense.boons.all || 0) +
+          (horrifyingBane && !this.system.horrifying && !this.system.frightening && target?.actor?.system.horrifying && 1 || 0))
       const boonsReroll = parseInt(this.system.bonuses.rerollBoon1Dice)
 
       attackRoll = new Roll(this.rollFormula(modifiers, boons, boonsReroll), this.system)
@@ -591,11 +601,14 @@ export class DemonlordActor extends Actor {
         (this.system.bonuses.attack.boons.all || 0) +
         (this.system.bonuses.attack.boons.spell || 0)
 
+      const horrifyingBane = game.settings.get('demonlord', 'horrifyingBane')
+
       if (targets.length > 0)
         boons -=
           (target?.actor?.system.bonuses.defense.boons[defenseAttribute] || 0) +
           (target?.actor?.system.bonuses.defense.boons.all || 0) +
-          (target?.actor?.system.bonuses.defense.boons.spell || 0)
+          (target?.actor?.system.bonuses.defense.boons.spell || 0) +
+          (horrifyingBane && !this.system.horrifying && !this.system.frightening && target?.actor?.system.horrifying && 1 || 0)
 
       const modifiers = [parseInt(inputModifier) || 0, this.getAttribute(attackAttribute).modifier || 0]
       const boonsReroll = parseInt(this.system.bonuses.rerollBoon1Dice)
@@ -669,7 +682,14 @@ export class DemonlordActor extends Actor {
         (this.system.bonuses.attack[attackAttribute] || 0) +
         (this.system.bonuses.attack.boons.all || 0) +
         parseInt(itemData.action?.boonsbanes || 0)
-      if (targets.length === 1) boons -= ((target?.actor?.system.bonuses.defense.boons[defenseAttribute] || 0) + (target?.actor?.system.bonuses.defense.boons.all || 0))
+
+      const horrifyingBane = game.settings.get('demonlord', 'horrifyingBane')
+
+      if (targets.length === 1)
+        boons -= (
+          (target?.actor?.system.bonuses.defense.boons[defenseAttribute] || 0) +
+          (target?.actor?.system.bonuses.defense.boons.all || 0) +
+          (horrifyingBane && !this.system.horrifying && !this.system.frightening && target?.actor?.system.horrifying && 1 || 0))
       const boonsReroll = parseInt(this.system.bonuses.rerollBoon1Dice)
 
       attackRoll = new Roll(this.rollFormula(modifiers, boons, boonsReroll), this.system)

--- a/src/module/chat/effect-messages.js
+++ b/src/module/chat/effect-messages.js
@@ -66,7 +66,12 @@ export function buildAttackEffectsMessage(attacker, defender, item, attackAttrib
   const attackerEffects = Array.from(attacker.allApplicableEffects()).filter(effect => !effect.disabled)
   let m = _remapEffects(attackerEffects)
 
-  let defenderBoons = (defender?.system.bonuses.defense.boons[defenseAttribute] || 0) + (defender?.system.bonuses.defense.boons.all || 0)
+  const horrifyingBane = game.settings.get('demonlord', 'horrifyingBane')
+
+  let defenderBoons = (
+    (defender?.system.bonuses.defense.boons[defenseAttribute] || 0) +
+    (defender?.system.bonuses.defense.boons.all || 0) +
+    (horrifyingBane && !attacker.system.horrifying && !attacker.system.frightening && defender?.system.horrifying && 1 || 0))
   const defenderString = defender?.name + '  [' + game.i18n.localize('DL.SpellTarget') + ']'
   let otherBoons = ''
   let inputBoonsMsg = inputBoons ? _toMsg(game.i18n.localize('DL.DialogInput'), plusify(inputBoons)) : ''

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -134,6 +134,14 @@ export const registerSettings = function () {
     type: Boolean,
     config: true,
   })
+  game.settings.register("demonlord", "horrifyingBane", {
+    name: game.i18n.localize('DL.SettingHorrifyingBane'),
+    hint: game.i18n.localize('DL.SettingHorrifyingBaneHint'),
+    default: true,
+    scope: 'world',
+    type: Boolean,
+    config: true,
+  })
   game.settings.register("demonlord", "diagonalMovement", {
     name: "DL.Setting.DiagonalRule",
     hint: "DL.Setting.DiagonalRuleHint",


### PR DESCRIPTION
Automatically add 1 bane on attack rolls targeting a horrifying creature if the attacker lacks the frightening or horrifying trait.
Can be disabled in the settings.