### PR TITLE
Fix: remove world time advance from rest

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -837,9 +837,6 @@ export class DemonlordActor extends Actor {
       if (restTime === 24) this.applyHealing(true)
     }
 
-    // Advance time according to the duration of the rest.
-    await game.time.advance(restTime * 60 * 60)
-
     var templateData = { actor: this, restTime, magicRecovery, talentRecovery, healing }
 
     const chatData = {


### PR DESCRIPTION
Advancing world time during rest automatically means world time will advance multiple times when several characters rest simultaneously.
Also, world time advance triggers a permission error for players depending on the permission configuration in the world.