### PR TITLE
New special duration: RestComplete, NextD20Roll deletion fixes, Effect name fix

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -631,6 +631,7 @@
   "DL.SpecialDurationTurnStart": "Turn Start: Expires at the start of the targets's next turn (in combat)",
   "DL.SpecialDurationTurnStartSource": "Turn Start: Expires at the start of the source actor's next turn (in combat)",
   "DL.SpecialDurationNextD20Roll": "Next d20 Roll: Expires at the targets's next Challenge/Attack Roll",
+  "DL.SpecialDurationRestComplete": "Rest Complete: Expires when the targets complete rest",  
   "DL.SpellAftereffect": "Aftereffect",
   "DL.SpellArea": "Area",
   "DL.SpellAttribute": "Attribute",

--- a/src/module/active-effects/effects.js
+++ b/src/module/active-effects/effects.js
@@ -193,7 +193,7 @@ Hooks.on('renderActiveEffectConfig', (app, html) => {
 
   dropDownConfig({
     specialDuration: 'specialDuration',
-    values: ['None', 'TurnStart', 'TurnEnd', 'TurnStartSource', 'TurnEndSource','NextD20Roll'],
+    values: ['None', 'TurnStart', 'TurnEnd', 'TurnStartSource', 'TurnEndSource','NextD20Roll','RestComplete'],
     default_value: 'None',
   })
 

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -428,7 +428,15 @@ export class DemonlordActor extends Actor {
   for (let effect of this.appliedEffects) {
     const specialDuration = foundry.utils.getProperty(effect, 'flags.specialDuration')
     if (!(specialDuration?.length > 0)) continue
-    if ((specialDuration === 'NextD20Roll' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) || (specialDuration === 'NextD20Roll' && !effect.changes.length)) await effect?.delete()
+      if (specialDuration === 'NextD20Roll') {
+        let nAttackAttribute =  attackAttribute.length ? attackAttribute : 'None'
+        if (
+          effect.changes.find(e => e.key.includes('system.bonuses.attack.boons.all')) || !effect.changes.length ||
+          effect.changes.find(e => e.key.includes(`system.bonuses.attack.boons.${nAttackAttribute}`)) ||
+          effect.changes.find(e => e.key.includes(`system.bonuses.attack.boons.weapon`))
+        )
+          await effect?.delete()
+      }
   }
 
     Hooks.call('DL.RollAttack', {
@@ -502,7 +510,13 @@ export class DemonlordActor extends Actor {
     for (let effect of this.appliedEffects) {
       const specialDuration = foundry.utils.getProperty(effect, 'flags.specialDuration')
       if (!(specialDuration?.length > 0)) continue
-      if ((specialDuration === 'NextD20Roll' && effect.changes.find((e) => e.key.includes('system.bonuses.challenge.boons'))) || (specialDuration === 'NextD20Roll' && !effect.changes.length)) await effect?.delete()        
+      if (specialDuration === 'NextD20Roll') {
+        if (
+          effect.changes.find(e => e.key.includes('system.bonuses.challenge.boons.all')) || !effect.changes.length ||
+          effect.changes.find(e => e.key.includes(`system.bonuses.challenge.boons.${attribute.key}`))
+        )
+          await effect?.delete()
+      }
     }
 
     return challengeRoll
@@ -578,7 +592,14 @@ export class DemonlordActor extends Actor {
       for (let effect of this.appliedEffects) {
         const specialDuration = foundry.utils.getProperty(effect, 'flags.specialDuration')
         if (!(specialDuration?.length > 0)) continue
-        if ((specialDuration === 'NextD20Roll' && attackAttribute !== '' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) || (specialDuration === 'NextD20Roll' && !effect.changes.length)) await effect?.delete()
+        if (specialDuration === 'NextD20Roll') {
+          let nAttackAttribute =  attackAttribute.length ? attackAttribute : 'None'
+          if (
+            effect.changes.find(e => e.key.includes('system.bonuses.attack.boons.all')) || !effect.changes.length ||
+            effect.changes.find(e => e.key.includes(`system.bonuses.attack.boons.${nAttackAttribute}`))
+          )
+            await effect?.delete()
+        }
       }
 
     }
@@ -670,7 +691,15 @@ export class DemonlordActor extends Actor {
     for (let effect of this.appliedEffects) {
       const specialDuration = foundry.utils.getProperty(effect, 'flags.specialDuration')
       if (!(specialDuration?.length > 0)) continue
-      if ((specialDuration === 'NextD20Roll' && attackAttribute !== '' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) || (specialDuration === 'NextD20Roll' && !effect.changes.length)) await effect?.delete()
+      if (specialDuration === 'NextD20Roll') {
+        let nAttackAttribute =  attackAttribute.length ? attackAttribute : 'None'
+        if (
+          effect.changes.find(e => e.key.includes('system.bonuses.attack.boons.all')) || !effect.changes.length ||
+          effect.changes.find(e => e.key.includes(`system.bonuses.attack.boons.${nAttackAttribute}`)) ||
+          effect.changes.find(e => e.key.includes(`system.bonuses.attack.boons.spell`))
+        )
+          await effect?.delete()
+      }
     }
 
     // Add concentration if it's in the spell duration
@@ -748,7 +777,7 @@ export class DemonlordActor extends Actor {
 
       let boons =
         (parseInt(inputBoons) || 0) +
-        (this.system.bonuses.attack[attackAttribute] || 0) +
+        (this.system.bonuses.attack.boons[attackAttribute] || 0) +
         (this.system.bonuses.attack.boons.all || 0) +
         parseInt(itemData.action?.boonsbanes || 0)
 
@@ -767,8 +796,15 @@ export class DemonlordActor extends Actor {
       for (let effect of this.appliedEffects) {
         const specialDuration = foundry.utils.getProperty(effect, 'flags.specialDuration')
         if (!(specialDuration?.length > 0)) continue
-        if ((specialDuration === 'NextD20Roll' && attackAttribute !== '' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) || (specialDuration === 'NextD20Roll' && !effect.changes.length)) await effect?.delete()
-      }  
+        if (specialDuration === 'NextD20Roll') {
+          let nAttackAttribute =  attackAttribute.length ? attackAttribute : 'None'
+          if (
+            effect.changes.find(e => e.key.includes('system.bonuses.attack.boons.all')) || !effect.changes.length ||
+            effect.changes.find(e => e.key.includes(`system.bonuses.attack.boons.${nAttackAttribute}`))
+          )
+            await effect?.delete()
+        }
+      }
     }
     postItemToChat(this, item, attackRoll, target?.actor, parseInt(inputBoons) || 0)
     return attackRoll

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -428,7 +428,7 @@ export class DemonlordActor extends Actor {
   for (let effect of this.appliedEffects) {
     const specialDuration = foundry.utils.getProperty(effect, 'flags.specialDuration')
     if (!(specialDuration?.length > 0)) continue
-    if (specialDuration === 'NextD20Roll' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) await effect?.delete()
+    if ((specialDuration === 'NextD20Roll' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) || (specialDuration === 'NextD20Roll' && !effect.changes.length)) await effect?.delete()
   }
 
     Hooks.call('DL.RollAttack', {
@@ -502,7 +502,7 @@ export class DemonlordActor extends Actor {
     for (let effect of this.appliedEffects) {
       const specialDuration = foundry.utils.getProperty(effect, 'flags.specialDuration')
       if (!(specialDuration?.length > 0)) continue
-      if (specialDuration === 'NextD20Roll' && effect.changes.find((e) => e.key.includes('system.bonuses.challenge.boons'))) await effect?.delete()        
+      if ((specialDuration === 'NextD20Roll' && effect.changes.find((e) => e.key.includes('system.bonuses.challenge.boons'))) || (specialDuration === 'NextD20Roll' && !effect.changes.length)) await effect?.delete()        
     }
 
     return challengeRoll
@@ -578,7 +578,7 @@ export class DemonlordActor extends Actor {
       for (let effect of this.appliedEffects) {
         const specialDuration = foundry.utils.getProperty(effect, 'flags.specialDuration')
         if (!(specialDuration?.length > 0)) continue
-        if (specialDuration === 'NextD20Roll' && attackAttribute !== '' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) await effect?.delete()
+        if ((specialDuration === 'NextD20Roll' && attackAttribute !== '' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) || (specialDuration === 'NextD20Roll' && !effect.changes.length)) await effect?.delete()
       }
 
     }
@@ -670,7 +670,7 @@ export class DemonlordActor extends Actor {
     for (let effect of this.appliedEffects) {
       const specialDuration = foundry.utils.getProperty(effect, 'flags.specialDuration')
       if (!(specialDuration?.length > 0)) continue
-      if (specialDuration === 'NextD20Roll' && attackAttribute !== '' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) await effect?.delete()
+      if ((specialDuration === 'NextD20Roll' && attackAttribute !== '' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) || (specialDuration === 'NextD20Roll' && !effect.changes.length)) await effect?.delete()
     }
 
     // Add concentration if it's in the spell duration
@@ -767,7 +767,7 @@ export class DemonlordActor extends Actor {
       for (let effect of this.appliedEffects) {
         const specialDuration = foundry.utils.getProperty(effect, 'flags.specialDuration')
         if (!(specialDuration?.length > 0)) continue
-        if (specialDuration === 'NextD20Roll' && attackAttribute !== '' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) await effect?.delete()
+        if ((specialDuration === 'NextD20Roll' && attackAttribute !== '' && effect.changes.find((e) => e.key.includes('system.bonuses.attack.boons'))) || (specialDuration === 'NextD20Roll' && !effect.changes.length)) await effect?.delete()
       }  
     }
     postItemToChat(this, item, attackRoll, target?.actor, parseInt(inputBoons) || 0)
@@ -910,6 +910,12 @@ export class DemonlordActor extends Actor {
       await this.applyHealing(true)
       if (restTime === 24) this.applyHealing(true)
     }
+
+		for (let effect of this.appliedEffects) {
+			const specialDuration = foundry.utils.getProperty(effect, "flags.specialDuration")
+			if (!(specialDuration?.length > 0)) continue
+			if (specialDuration === 'RestComplete') await effect?.delete()
+		}
 
     var templateData = { actor: this, restTime, magicRecovery, talentRecovery, healing }
 

--- a/src/module/chat/chat-listeners.js
+++ b/src/module/chat/chat-listeners.js
@@ -225,6 +225,17 @@ async function _onChatApplyEffect(event) {
   }
 
   const effectData = activeEffect.toObject()
+  //Repace origin with Item UUID, otherwise effect cannot be removed
+  //specialDuration: TurnStartSource, TurnEndSource
+
+  let aeUuid = activeEffect.uuid
+  let effectOrigin = aeUuid.substr(0, aeUuid.search('.ActiveEffect.'))
+  let effectOriginName = fromUuidSync(effectOrigin).name
+  if (activeEffect.origin.startsWith('Compendium')) {
+    effectData.origin = effectOrigin
+  }
+  if (effectData.name !== effectOriginName)  effectData.name = `${effectData.name} [${effectOriginName}]`  
+  
   for await (const target of selected) {
     // First check if the actor already has this effect
     const matchingEffects = target.actor.effects.filter(e => e.name === effectData.name && changesMatch(e.changes, effectData.changes))
@@ -235,18 +246,6 @@ async function _onChatApplyEffect(event) {
         await e.delete()
       }
     }
-
-
-  //Repace origin with Item UUID, otherwise effect cannot be removed
-  //specialDuration: TurnStartSource, TurnEndSource
-
-  let aeUuid = activeEffect.uuid
-  let effectOrigin = aeUuid.substr(0, aeUuid.search('.ActiveEffect.'))
-  let effectOriginName = fromUuidSync(effectOrigin).name
-  if (activeEffect.origin.startsWith('Compendium')) {
-    effectData.origin = effectOrigin
-  }
-  if (effectData.name !== effectOriginName)  effectData.name = `${effectData.name} [${effectOriginName}]`
 
     await ActiveEffect.create(effectData, {parent: target.actor}).then(e => ui.notifications.info(`Added "${e.name}" to "${target.actor.name}"`))
   }

--- a/src/module/combat/combat.js
+++ b/src/module/combat/combat.js
@@ -499,7 +499,7 @@ async function deleteSpecialdurationEffects(combatant) {
   for (let effect of actor.appliedEffects) {
       const specialDuration = foundry.utils.getProperty(effect, "flags.specialDuration")
       if (!(specialDuration?.length > 0)) continue
-      if (specialDuration !== "None" && specialDuration !== undefined) await effect?.delete()
+      if (specialDuration !== "None" && specialDuration !== undefined && specialDuration !== 'RestComplete') await effect?.delete()
   }
 }
 
@@ -510,7 +510,7 @@ Hooks.on('deleteCombat', async (combat) => {
 		for (let effect of testActor.appliedEffects) {
 			const specialDuration = foundry.utils.getProperty(effect, "flags.specialDuration")
 			if (!(specialDuration?.length > 0)) continue
-			if (specialDuration !== "None" && specialDuration !== undefined) await effect?.delete()
+			if (specialDuration !== "None" && specialDuration !== undefined && specialDuration !== 'RestComplete') await effect?.delete()
 		}
 	}
 })


### PR DESCRIPTION
Added: New special duration: RestComplete

Fixed: Incorrect effect name, when applying effect on multiple target.
Fixed: EndOfTheRound ignores system.bonuses.attack.boons.attribute.
Fixed: NextD20Roll ignores system.bonuses.attack.boons.attribute, system.bonuses.attack.boons.weapon and system.bonuses.attack.boons.spell on deletion.