### PR TITLE
Option to hide actor info from chat messages

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -603,6 +603,8 @@
   "DL.SettingConfirmAncestryPathRemovalHint": "Show a confirmation dialog when attempting to remove an ancestry or path from a character of level 1 or higher.",
   "DL.SettingGMEffectsControls": "GM Effects Controls",
   "DL.SettingGMEffectsControlsHint": "Always show the active effects controls in the character sheets (toggle, edit and delete) to the Game Master, regardless of the effect type.",
+  "DL.SettingHideActorInfo": "Hide actor info from chat messages",
+  "DL.SettingHideActorInfoHint": "Actor info (ancestry, path, size, frightening/horrifying traits) will be displayed to owner and GM only.",
   "DL.SettingHorrifyingBane": "Bane against horrifying creatures",
   "DL.SettingHorrifyingBaneHint": "Apply a bane on all attack rolls targeting a horrifying creature, unless the attacker has the frightening or horrifying trait.",
   "DL.SettingInitMessage": "Initiative Messages",

--- a/src/module/chat/base-messages.js
+++ b/src/module/chat/base-messages.js
@@ -31,10 +31,10 @@ export function buildActorInfo(actor) {
     const ancestry = actor.items.find(i => i.type === 'ancestry')?.name || ''
     const pathsData = actor.items.filter(i => i.type === 'path').map(p => p.system)
     const path =
-      pathsData.find(p => p.type === 'novice')?.name ||
-      pathsData.find(p => p.type === 'expert')?.name ||
-      pathsData.find(p => p.type === 'master')?.name ||
-      pathsData.find(p => p.type === 'legendary')?.name ||
+      pathsData.find(p => p.type === 'novice')?.parent.name ||
+      pathsData.find(p => p.type === 'expert')?.parent.name ||
+      pathsData.find(p => p.type === 'master')?.parent.name ||
+      pathsData.find(p => p.type === 'legendary')?.parent.name ||
       ''
     info = ancestry + (path ? ', ' + path : '')
   } else {

--- a/src/module/demonlord.js
+++ b/src/module/demonlord.js
@@ -389,6 +389,8 @@ Hooks.on('renderChatMessage', async (app, html, _msg) => {
   if (!game.user.isGM) {
     html.find('.gmonly').remove()
     html.find('.gmonlyzero').remove()
+    let messageActor = app.speaker.actor
+    if (!game.actors.get(messageActor)?.isOwner && game.settings.get('demonlord', 'hideActorInfo')) html.find('.showlessinfo').remove()
   } else html.find('.gmremove').remove()
 })
 

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -268,6 +268,14 @@ export const registerSettings = function () {
     type: Boolean,
     config: true,
   })
+  game.settings.register('demonlord', 'hideActorInfo', {
+    name: game.i18n.localize('DL.SettingHideActorInfo'),
+    hint: game.i18n.localize('DL.SettingHideActorInfoHint'),
+    default: false,
+    scope: 'world',
+    type: Boolean,
+    config: true,
+  })
   game.settings.register('demonlord', 'statusIcons', {
     name: game.i18n.localize('DL.SettingStatusIcons'),
     hint: game.i18n.localize('DL.SettingStatusIconsHint'),


### PR DESCRIPTION
Added: Option to hide actor info from chat messages for non-owned actors.
Fixed: Actor info does not contain path description
![image](https://github.com/user-attachments/assets/e280bab9-6ac5-4402-80a8-74222f4114f9)
![image](https://github.com/user-attachments/assets/139aea5f-c556-4dca-8a0e-dbafa53672ca)

