### PR TITLE
Option to show/hide creature activity descriptions

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -614,6 +614,8 @@
   "DL.SettingGMEffectsControlsHint": "Always show the active effects controls in the character sheets (toggle, edit and delete) to the Game Master, regardless of the effect type.",
   "DL.SettingHideActorInfo": "Hide actor info from chat messages",
   "DL.SettingHideActorInfoHint": "Actor info (ancestry, path, size, frightening/horrifying traits) will be displayed to owner and GM only.",
+  "DL.SettingHideCreatureDescription": "Hide creature activity descriptions from chat.",
+  "DL.SettingHideCreatureDescriptionHint": "Creature activity descriptions will be displayed to GM only.",
   "DL.SettingHorrifyingBane": "Bane against horrifying creatures",
   "DL.SettingHorrifyingBaneHint": "Apply a bane on all attack rolls targeting a horrifying creature, unless the attacker has the frightening or horrifying trait.",
   "DL.SettingInitMessage": "Initiative Messages",

--- a/src/module/demonlord.js
+++ b/src/module/demonlord.js
@@ -404,6 +404,7 @@ Hooks.on('renderChatMessage', async (app, html, _msg) => {
     html.find('.gmonlyzero').remove()
     let messageActor = app.speaker.actor
     if (!game.actors.get(messageActor)?.isOwner && game.settings.get('demonlord', 'hideActorInfo')) html.find('.showlessinfo').remove()
+    if (!game.actors.get(messageActor)?.isOwner && game.settings.get('demonlord', 'hideDescription')) html.find('.showdescription').empty()
   } else html.find('.gmremove').remove()
 })
 

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -332,6 +332,16 @@ export const registerSettings = function () {
     scope: 'world',
     type: Boolean,
     config: true,
+    onChange: foundry.utils.debouncedReload
+  })
+  game.settings.register('demonlord', 'hideDescription', {
+    name: game.i18n.localize('DL.SettingHideCreatureDescription'),
+    hint: game.i18n.localize('DL.SettingHideCreatureDescriptionHint'),
+    default: true,
+    scope: 'world',
+    type: Boolean,
+    config: true,
+    onChange: foundry.utils.debouncedReload
   })
   game.settings.register('demonlord', 'statusIcons', {
     name: game.i18n.localize('DL.SettingStatusIcons'),

--- a/src/templates/chat/partial/chat-description.hbs
+++ b/src/templates/chat/partial/chat-description.hbs
@@ -6,7 +6,7 @@
 
 {{#if description}}
 {{#if isCreature}}
-<div class="gmonly">
+<div class="showdescription">
   <div class="description">
     <div class="header">{{localize "DL.AttackRollDescription"}}</div>
     <div class="body">{{{description}}}</div>


### PR DESCRIPTION
Show
![image](https://github.com/user-attachments/assets/3bc78dbc-da4c-4b9b-bb19-f0532f781c19)
Hide
![image](https://github.com/user-attachments/assets/fe1cfafb-a89d-4956-995c-f13cce33480b)
