### PR TITLE
Fix boon/bane dialog for attack spells when using non-English locale

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -736,7 +736,7 @@ export class DemonlordActor extends Actor {
 
   async rollSpell(itemID, _options = {event: null}) {
     const item = this.items.get(itemID)
-    const isAttack = item.system.spelltype === game.i18n.localize('DL.SpellTypeAttack')
+    const isAttack = item.system.spelltype === 'Attack'
     const attackAttribute = item.system?.action?.attack?.toLowerCase()
     const challengeAttribute = item.system?.attribute?.toLowerCase()
 


### PR DESCRIPTION
Spells with "Attack" type have an extra dialog where you can select boons/bane. This dialog does not appear when using non-English locale.

Internal logic for this uses comparison of `item.system.spelltype` to localized string of spell type. In case of Spanish, for example, this means `"Attack" === "Ataque"`, which is always false.

I'm not sure what was the original intent with using a localized string there, but changing this condition to use "Attack" constant seem to solve the issue for me.