### PR TITLE
Option to hide damage/effect buttons from chat messages when attack roll fails.

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -635,6 +635,8 @@
   "DL.SettingHideActorInfoHint": "Actor info (ancestry, path, size, frightening/horrifying traits) will be displayed to owner and GM only.",
   "DL.SettingHideCreatureDescription": "Hide creature activity descriptions from chat.",
   "DL.SettingHideCreatureDescriptionHint": "Creature activity descriptions will be displayed to GM only.",
+  "DL.SettingHideDamage": "Hide damage/effect buttons from chat messages when attack roll fails.",
+  "DL.SettingHideDamageHint": "If target is not selected damage/effect buttons are always visible.",
   "DL.SettingHorrifyingBane": "Bane against horrifying creatures",
   "DL.SettingHorrifyingBaneHint": "Apply a bane on all attack rolls targeting a horrifying creature, unless the attacker has the frightening or horrifying trait.",
   "DL.SettingInitMessage": "Initiative Messages",

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -729,7 +729,7 @@ export class DemonlordActor extends Actor {
       attackRoll: attackRoll
     })
 
-    postTalentToChat(this, talent, attackRoll, target?.actor, parseInt(inputBoons) || 0)
+    postTalentToChat(this, talent, attackRoll, target?.actor, parseInt(inputBoons) || 0, parseInt(inputModifier) || 0)
     return attackRoll
   }
 
@@ -816,7 +816,7 @@ export class DemonlordActor extends Actor {
       attackRoll: attackRoll
     })
 
-    postSpellToChat(this, spell, attackRoll, target?.actor, parseInt(inputBoons) || 0)
+    postSpellToChat(this, spell, attackRoll, target?.actor, parseInt(inputBoons) || 0, parseInt(inputModifier) || 0)
 
     for (let effect of this.appliedEffects) {
       const specialDuration = foundry.utils.getProperty(effect, `flags.${game.system.id}.specialDuration`)

--- a/src/module/chat/effect-messages.js
+++ b/src/module/chat/effect-messages.js
@@ -144,7 +144,7 @@ export function buildAttackEffectsMessage(attacker, defender, item, attackAttrib
     (applyHorrifyingBane ? horrifyingTextGM : '') +
     (playerOnlyMsg ? playerOnlyMsg : '') +
     (gmOnlyMsg ? gmOnlyMsg : '')
-  boonsMsg = boonsMsg ? `&nbsp;&nbsp;${game.i18n.localize('DL.TalentAttackBoonsBanes')}<br>` + boonsMsg : ''
+  boonsMsg = boonsMsg+inputBoonsMsg ? `&nbsp;&nbsp;${game.i18n.localize('DL.TalentAttackBoonsBanes')}<br>` + boonsMsg+inputBoonsMsg : ''
   
   let modifiersMsg =
     changeListToMsg(m, [`system.bonuses.attack.modifier.${attackAttribute}`,"system.bonuses.attack.modifier.all"], '') +
@@ -155,9 +155,8 @@ export function buildAttackEffectsMessage(attacker, defender, item, attackAttrib
   // We may want to show the extra damage
   const extraDamage20PlusMsg = ((!defender && attackAttribute) || plus20) ? changeToMsg(m, 'system.bonuses.attack.plus20Damage', 'DL.TalentExtraDamage20plus') : ''
   return (
-    modifiersMsg +
     boonsMsg +
-    inputBoonsMsg +
+    modifiersMsg +
     extraDamageMsg +
     extraDamage20PlusMsg
   )

--- a/src/module/chat/roll-messages.js
+++ b/src/module/chat/roll-messages.js
@@ -93,11 +93,15 @@ export function postAttackToChat(attacker, defender, item, attackRoll, attackAtt
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  data['damageFormula'] = itemData?.action?.damage
-  data['extraDamageFormula'] = extraDamage
-  data['damageType'] = itemData.action.damagetype
-  data['damageTypes'] = itemData.action.damagetypes
-  data['damageExtra20PlusFormula'] = itemData.action?.plus20damage + extraDamage20Plus
+  if ((defender !== undefined && attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || defender === undefined || !game.settings.get('demonlord', 'hideDamage'))
+  {
+    data['damageFormula'] = itemData?.action?.damage
+    data['extraDamageFormula'] = extraDamage
+    data['damageType'] = itemData.action.damagetype
+    data['damageTypes'] = itemData.action.damagetypes
+    data['damageExtra20PlusFormula'] = itemData.action?.plus20damage + extraDamage20Plus
+    data['itemEffects'] = item.effects
+  }
   data['description'] = itemData.description
   data['defense'] = itemData.action?.defense
   data['defenseboonsbanes'] = parseInt(itemData.action?.defenseboonsbanes)
@@ -116,7 +120,6 @@ export function postAttackToChat(attacker, defender, item, attackRoll, attackAtt
   data['afflictionEffects'] = '' //TODO
   data['ifBlindedRoll'] = rollMode === 'blindroll'
   data['hasAreaTarget'] = itemData.activatedEffect?.target?.type in CONFIG.DL.actionAreaShape
-  data['itemEffects'] = item.effects
   data['actorInfo'] = buildActorInfo(attacker)
 
   const chatData = getChatBaseData(attacker, rollMode)
@@ -268,11 +271,15 @@ export function postTalentToChat(actor, talent, attackRoll, target, inputBoons) 
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  data['damageFormula'] = talentData?.action?.damage
-  data['extraDamageFormula'] = extraDamage
-  data['damageType'] = talentData.action?.damageactive && talentData?.action?.damage ? talentData?.action?.damagetype : talentData?.action?.damagetype
-  data['damageTypes'] = talentData.action?.damagetypes
-  data['damageExtra20PlusFormula'] = talentData.action?.plus20damage + extraDamage20Plus
+  if ((target !== undefined && attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || target === undefined || !game.settings.get('demonlord', 'hideDamage'))
+  {
+    data['damageFormula'] = talentData?.action?.damage
+    data['extraDamageFormula'] = extraDamage
+    data['damageType'] = talentData.action?.damageactive && talentData?.action?.damage ? talentData?.action?.damagetype : talentData?.action?.damagetype
+    data['damageTypes'] = talentData.action?.damagetypes
+    data['damageExtra20PlusFormula'] = talentData.action?.plus20damage + extraDamage20Plus
+    data['itemEffects'] = talent.effects
+  }  
   data['description'] = talentData.description
   data['defense'] = talentData.action?.defense
   data['defenseboonsbanes'] = parseInt(talentData.action?.defenseboonsbanes)
@@ -293,7 +300,6 @@ export function postTalentToChat(actor, talent, attackRoll, target, inputBoons) 
   data['effects'] = buildTalentEffectsMessage(actor, talent)
   data['ifBlindedRoll'] = rollMode === 'blindroll'
   data['hasAreaTarget'] = talentData?.activatedEffect?.target?.type in CONFIG.DL.actionAreaShape
-  data['itemEffects'] = talent.effects
   data['actorInfo'] = buildActorInfo(actor)
 
   const chatData = getChatBaseData(actor, rollMode)
@@ -390,11 +396,15 @@ export async function postSpellToChat(actor, spell, attackRoll, target, inputBoo
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  data['damageFormula'] = spellData?.action?.damage
-  data['extraDamageFormula'] = extraDamage
-  data['damageType'] = spellData.action?.damagetype
-  data['damageTypes'] = spellData.action?.damagetypes
-  data['damageExtra20PlusFormula'] = spellData.action?.plus20damage + extraDamage20Plus
+  if ((target !== undefined && attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || target === undefined || !game.settings.get('demonlord', 'hideDamage'))
+  {
+    data['damageFormula'] = spellData?.action?.damage
+    data['extraDamageFormula'] = extraDamage
+    data['damageType'] = spellData.action?.damagetype
+    data['damageTypes'] = spellData.action?.damagetypes
+    data['damageExtra20PlusFormula'] = spellData.action?.plus20damage + extraDamage20Plus
+    data['itemEffects'] = spell.effects
+  }
   data['description'] = spellData.description
   data['defense'] = spellData.action?.defense
   data['defenseboonsbanes'] = parseInt(spellData.action?.defenseboonsbanes)
@@ -426,7 +436,6 @@ export async function postSpellToChat(actor, spell, attackRoll, target, inputBoo
   data['attackEffects'] = buildAttackEffectsMessage(actor, target, spell, attackAttribute, defenseAttribute, inputBoons, plus20)
   data['ifBlindedRoll'] = rollMode === 'blindroll'
   data['hasAreaTarget'] = spellData?.activatedEffect?.target?.type in CONFIG.DL.actionAreaShape
-  data['itemEffects'] = spell.effects
   data['actorInfo'] = buildActorInfo(actor)
 
   const chatData = getChatBaseData(actor, rollMode)
@@ -600,11 +609,15 @@ export const postItemToChat = (actor, item, attackRoll, target, inputBoons) => {
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  data['damageFormula'] = itemData?.action?.damage
-  data['extraDamageFormula'] = extraDamage
-  data['damageType'] = itemData.action?.damagetype
-  data['damageTypes'] = itemData.action?.damagetypes
-  data['damageExtra20PlusFormula'] = itemData.action?.plus20damage + extraDamage20Plus
+  if ((target !== undefined && attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || target === undefined || !game.settings.get('demonlord', 'hideDamage'))
+  {
+    data['damageFormula'] = itemData?.action?.damage
+    data['extraDamageFormula'] = extraDamage
+    data['damageType'] = itemData.action?.damagetype
+    data['damageTypes'] = itemData.action?.damagetypes
+    data['damageExtra20PlusFormula'] = itemData.action?.plus20damage + extraDamage20Plus
+    data['itemEffects'] = item.effects
+  }
   data['description'] = itemData.description
   data['defense'] = itemData.action?.defense
   data['defenseboonsbanes'] = parseInt(itemData.action?.defenseboonsbanes)
@@ -623,7 +636,6 @@ export const postItemToChat = (actor, item, attackRoll, target, inputBoons) => {
   data['afflictionEffects'] = '' //TODO
   data['ifBlindedRoll'] = rollMode === 'blindroll'
   data['hasAreaTarget'] = itemData.activatedEffect?.target?.type in CONFIG.DL.actionAreaShape
-  data['itemEffects'] = item.effects
   data['actorInfo'] = buildActorInfo(actor)
 
   const chatData = getChatBaseData(actor, rollMode)

--- a/src/module/chat/roll-messages.js
+++ b/src/module/chat/roll-messages.js
@@ -205,7 +205,7 @@ export function postAttributeToChat(actor, attribute, challengeRoll, inputBoons,
  * @param attackRoll    Roll
  * @param target        DemonlordActor
  */
-export function postTalentToChat(actor, talent, attackRoll, target, inputBoons) {
+export function postTalentToChat(actor, talent, attackRoll, target, inputBoons, inputModifier) {
 
   attackRoll = changeBobDieColour (attackRoll)
 
@@ -296,7 +296,7 @@ export function postTalentToChat(actor, talent, attackRoll, target, inputBoons) 
   data['hasTarget'] = targetNumber !== undefined
   data['pureDamage'] = talentData?.damage
   data['pureDamageType'] = talentData?.damagetype
-  data['attackEffects'] = buildAttackEffectsMessage(actor, target, talent, attackAttribute, defenseAttribute, inputBoons, plus20)
+  data['attackEffects'] = buildAttackEffectsMessage(actor, target, talent, attackAttribute, defenseAttribute, inputBoons, plus20, inputModifier)
   data['effects'] = buildTalentEffectsMessage(actor, talent)
   data['ifBlindedRoll'] = rollMode === 'blindroll'
   data['hasAreaTarget'] = talentData?.activatedEffect?.target?.type in CONFIG.DL.actionAreaShape
@@ -327,7 +327,7 @@ export function postTalentToChat(actor, talent, attackRoll, target, inputBoons) 
  * @param attackRoll
  * @param target
  */
-export async function postSpellToChat(actor, spell, attackRoll, target, inputBoons) {
+export async function postSpellToChat(actor, spell, attackRoll, target, inputBoons, inputModifier) {
 
   attackRoll = changeBobDieColour (attackRoll)
 
@@ -433,7 +433,7 @@ export async function postSpellToChat(actor, spell, attackRoll, target, inputBoo
   data['isPlus20Roll'] = plus20
   data['effectdice'] = effectdice
   data['effects'] = actor.system.bonuses.attack.extraEffect
-  data['attackEffects'] = buildAttackEffectsMessage(actor, target, spell, attackAttribute, defenseAttribute, inputBoons, plus20)
+  data['attackEffects'] = buildAttackEffectsMessage(actor, target, spell, attackAttribute, defenseAttribute, inputBoons, plus20, inputModifier)
   data['ifBlindedRoll'] = rollMode === 'blindroll'
   data['hasAreaTarget'] = spellData?.activatedEffect?.target?.type in CONFIG.DL.actionAreaShape
   data['actorInfo'] = buildActorInfo(actor)

--- a/src/module/chat/roll-messages.js
+++ b/src/module/chat/roll-messages.js
@@ -93,7 +93,7 @@ export function postAttackToChat(attacker, defender, item, attackRoll, attackAtt
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  if ((defender !== undefined && attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || defender === undefined || !game.settings.get('demonlord', 'hideDamage'))
+  if ((attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || targetNumber === undefined || !game.settings.get('demonlord', 'hideDamage'))
   {
     data['damageFormula'] = itemData?.action?.damage
     data['extraDamageFormula'] = extraDamage
@@ -271,7 +271,7 @@ export function postTalentToChat(actor, talent, attackRoll, target, inputBoons, 
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  if ((target !== undefined && attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || target === undefined || !game.settings.get('demonlord', 'hideDamage'))
+  if ((attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || targetNumber === undefined || !game.settings.get('demonlord', 'hideDamage'))
   {
     data['damageFormula'] = talentData?.action?.damage
     data['extraDamageFormula'] = extraDamage
@@ -396,7 +396,7 @@ export async function postSpellToChat(actor, spell, attackRoll, target, inputBoo
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  if ((target !== undefined && attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || target === undefined || !game.settings.get('demonlord', 'hideDamage'))
+  if ((attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || targetNumber === undefined || !game.settings.get('demonlord', 'hideDamage'))
   {
     data['damageFormula'] = spellData?.action?.damage
     data['extraDamageFormula'] = extraDamage
@@ -609,7 +609,7 @@ export const postItemToChat = (actor, item, attackRoll, target, inputBoons) => {
   data['against'] = defenseAttribute ? game.i18n.localize(CONFIG.DL.attributes[defenseAttribute]?.toUpperCase()) : ''
   data['againstNumber'] = defenseAttributeImmune ? '-' : againstNumber
   data['againstNumberGM'] = defenseAttributeImmune ? '-' : (againstNumber === '?' ? targetNumber : againstNumber)
-  if ((target !== undefined && attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || target === undefined || !game.settings.get('demonlord', 'hideDamage'))
+  if ((attackRoll?.total >= targetNumber && game.settings.get('demonlord', 'hideDamage')) || targetNumber === undefined || !game.settings.get('demonlord', 'hideDamage'))  
   {
     data['damageFormula'] = itemData?.action?.damage
     data['extraDamageFormula'] = extraDamage

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -516,6 +516,14 @@ export const registerSettings = function () {
     config: true,
     requiresReload: true,
   })
+  game.settings.register('demonlord', 'hideDamage', {
+    name: game.i18n.localize('DL.SettingHideDamage'),
+    hint: game.i18n.localize('DL.SettingHideDamageHint'),
+    default: false,
+    scope: 'world',
+    type: Boolean,
+    config: true,
+  })  
   game.settings.register('demonlord', 'statusIcons', {
     name: game.i18n.localize('DL.SettingStatusIcons'),
     hint: game.i18n.localize('DL.SettingStatusIconsHint'),


### PR DESCRIPTION
<img width="1061" height="71" alt="image" src="https://github.com/user-attachments/assets/621eac33-4dc7-4019-939f-007705667f3a" />


Before:
<img width="302" height="313" alt="image" src="https://github.com/user-attachments/assets/ede5b80f-c021-4d5e-9f3b-6214e3d87182" />

<img width="300" height="374" alt="image" src="https://github.com/user-attachments/assets/7ab495e9-58ec-4cbf-aa97-ca955527faf2" />



After:
<img width="297" height="296" alt="image" src="https://github.com/user-attachments/assets/abcf03f2-cdc5-42f3-b365-aef16bc9667f" />
<img width="294" height="345" alt="image" src="https://github.com/user-attachments/assets/812e9c2a-4834-4782-8a84-709f149cb231" />
