### PR TITLE
Fix active effect interactions on items and characters

### DIFF
--- a/src/module/active-effects/effects.js
+++ b/src/module/active-effects/effects.js
@@ -10,16 +10,20 @@ import {i18n} from "../utils/utils";
 
 export async function onManageActiveEffect(event, owner) {
   event.preventDefault()
-  const a = event.currentTarget
+  const a = event.target.closest('a')
   const li = a.closest('li')
   switch (a.dataset.action) {
     case 'create':
+    case 'createEffect':
       return await onCreateEffect(li, owner)
     case 'edit':
+    case 'editEffect':
       return await onEditEffect(li, owner)
     case 'delete':
+    case 'deleteEffect':
       return await onDeleteEffect(li, owner)
     case 'toggle':
+    case 'toggleEffect':
       return await onToggleEffect(li, owner)
   }
 }
@@ -35,7 +39,7 @@ export async function onCreateEffect(listItem, owner) {
             transfer: false,
             flags: { demonlord: {sourceType: owner.type } },
             duration: {
-              value: listItem.dataset.effectType === 'temporary' ? 1 : Infinity,
+              value: listItem.dataset.effectType === 'temporary' ? 1 : null,
               units: 'rounds',
               expiry: null
             },

--- a/src/module/item/sheets/base-item-sheet.js
+++ b/src/module/item/sheets/base-item-sheet.js
@@ -425,9 +425,8 @@ export default class DLBaseItemSheet extends HandlebarsApplicationMixin(ItemShee
   }
 
   static async onManageEffect(event) {
-    const li = event.target.closest('li')
 
-    await onManageActiveEffect(li, this.document)
+    await onManageActiveEffect(event, this.document)
   }
 
   static async onEditDamage(event) {


### PR DESCRIPTION
1. Passive Active Effects failed to create on Characters because of `Infinite` duration. Now `null`.
2. No interactions were possible with Active Effects on items (create, edit, delete, toggle). `onManageEffect` in `base-item-sheet.js` passed an html item instead of the event to `onManageActiveEffect` from `effects.js`, and there was a mismatch on the values of the `data-action` property in the `item-effects.hbs` template: `create` expected instead of `createEffect`.*

*I didn't change the values in the Handlebars template because it broke the event handling for some reason, so I just added `createEffect`, `editEffect`, etc. as also valid values in the `onManageActiveEffects` handler.